### PR TITLE
Update to 2.47.0 and Example Script

### DIFF
--- a/2.42.3/client.lua
+++ b/2.42.3/client.lua
@@ -1,0 +1,2072 @@
+if not lib then return end
+
+require 'modules.bridge.client'
+require 'modules.interface.client'
+
+local Utils = require 'modules.utils.client'
+local Weapon = require 'modules.weapon.client'
+local currentWeapon
+
+--Holgers Anpassungen
+
+HotbarundWeaponWheel = false
+EnableWeaponWheel = true
+Waffencache = {}
+
+--Holgers Anpassungen bis hier
+
+exports('getCurrentWeapon', function()
+	return currentWeapon
+end)
+
+RegisterNetEvent('ox_inventory:disarm', function(noAnim)
+	currentWeapon = Weapon.Disarm(currentWeapon, noAnim)
+end)
+
+RegisterNetEvent('ox_inventory:clearWeapons', function()
+	Weapon.ClearAll(currentWeapon)
+end)
+
+local StashTarget
+
+exports('setStashTarget', function(id, owner)
+	StashTarget = id and {id=id, owner=owner}
+end)
+
+---@type boolean | number
+local invBusy = true
+
+---@type boolean?
+local invOpen = false
+local plyState = LocalPlayer.state
+local IsPedCuffed = IsPedCuffed
+local playerPed = cache.ped
+
+lib.onCache('ped', function(ped)
+	playerPed = ped
+	Utils.WeaponWheel()
+end)
+
+plyState:set('invBusy', true, true)
+plyState:set('invHotkeys', false, false)
+plyState:set('canUseWeapons', false, false)
+
+local function canOpenInventory()
+    if not PlayerData.loaded then
+        return shared.info('cannot open inventory', '(player inventory has not loaded)')
+    end
+
+    if IsPauseMenuActive() then return end
+
+    if invBusy or invOpen == nil or (currentWeapon?.timer or 0) > 0 then
+        return shared.info('cannot open inventory', '(is busy)')
+    end
+
+    if PlayerData.dead or IsPedFatallyInjured(playerPed) then
+        return shared.info('cannot open inventory', '(fatal injury)')
+    end
+
+    if PlayerData.cuffed or IsPedCuffed(playerPed) then
+        return shared.info('cannot open inventory', '(cuffed)')
+    end
+
+    return true
+end
+
+---@param ped number
+---@return boolean
+local function canOpenTarget(ped)
+	return IsPedFatallyInjured(ped)
+	or IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3)
+	or IsPedCuffed(ped)
+	or IsEntityPlayingAnim(ped, 'mp_arresting', 'idle', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_enter', 3)
+	or IsEntityPlayingAnim(ped, 'random@mugging3', 'handsup_standing_base', 3)
+end
+
+local defaultInventory = {
+	type = 'newdrop',
+	slots = shared.playerslots,
+	weight = 0,
+	maxWeight = shared.playerweight,
+	items = {}
+}
+
+local currentInventory = defaultInventory
+
+local function closeTrunk()
+	if currentInventory?.type == 'trunk' then
+		local coords = GetEntityCoords(playerPed, true)
+		---@todo animation for vans?
+		Utils.PlayAnimAdvanced(0, 'anim@heists@fleeca_bank@scope_out@return_case', 'trevor_action', coords.x, coords.y, coords.z, 0.0, 0.0, GetEntityHeading(playerPed), 2.0, 2.0, 1000, 49, 0.25)
+
+		CreateThread(function()
+			local entity = currentInventory.entity
+			local door = currentInventory.door
+			Wait(900)
+
+			if type(door) == 'table' then
+				for i = 1, #door do
+					SetVehicleDoorShut(entity, door[i], false)
+				end
+			else
+				SetVehicleDoorShut(entity, door, false)
+			end
+		end)
+	end
+end
+
+local CraftingBenches = require 'modules.crafting.client'
+local Vehicles = lib.load('data.vehicles')
+local Inventory = require 'modules.inventory.client'
+
+---@param inv string?
+---@param data any?
+---@return boolean?
+function client.openInventory(inv, data)
+	if invOpen then
+		if not inv and currentInventory.type == 'newdrop' then
+			return client.closeInventory()
+		end
+
+		if IsNuiFocused() then
+			if inv == 'container' and currentInventory.id == PlayerData.inventory[data].metadata.container then
+				return client.closeInventory()
+			end
+
+			if currentInventory.type == 'drop' and (not data or currentInventory.id == (type(data) == 'table' and data.id or data)) then
+				return client.closeInventory()
+			end
+
+			if inv ~= 'drop' and inv ~= 'container' then
+				if (data?.id or data) == currentInventory?.id then
+					-- Triggering exports.ox_inventory:openInventory('stash', 'mystash') twice in rapid succession is weird behaviour
+					return warn(("script tried to open inventory, but it is already open\n%s"):format(Citizen.InvokeNative(`FORMAT_STACK_TRACE` & 0xFFFFFFFF, nil, 0, Citizen.ResultAsString())))
+				else
+					return client.closeInventory()
+				end
+			end
+		end
+	elseif IsNuiFocused() then
+		-- If triggering from another nui, may need to wait for focus to end.
+		Wait(100)
+
+        -- People still complain about this being an "error" and ask "how fix" despite being a warning
+        -- for people with above room-temperature iqs to look into resource conflicts on their own.
+		-- if IsNuiFocused() then
+		-- 	warn('other scripts have nui focus and may cause issues (e.g. disable focus, prevent input, overlap inventory window)')
+		-- end
+	end
+
+	if inv == 'dumpster' and cache.vehicle then
+		return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+	end
+
+	if not canOpenInventory() then
+        return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+    end
+
+    local left, right, accessError
+
+    if inv == 'player' and data ~= cache.serverId then
+        local targetId, targetPed
+
+        if not data then
+            targetId, targetPed = Utils.GetClosestPlayer()
+            data = targetId and GetPlayerServerId(targetId)
+        else
+            local serverId = type(data) == 'table' and data.id or data
+
+            if serverId == cache.serverId then return end
+
+            targetId = serverId and GetPlayerFromServerId(serverId)
+            targetPed = targetId and GetPlayerPed(targetId)
+        end
+
+        local targetCoords = targetPed and GetEntityCoords(targetPed)
+
+        if not targetCoords or #(targetCoords - GetEntityCoords(playerPed)) > 1.8 or not (client.hasGroup(shared.police) or canOpenTarget(targetPed)) then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+    end
+
+    if inv == 'shop' and invOpen == false then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
+    elseif inv == 'crafting' then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+
+        if left then
+            right = CraftingBenches[data.id]
+
+            if not right?.items then return end
+
+            local coords, distance
+
+            if not right.zones and not right.points then
+                coords = GetEntityCoords(cache.ped)
+                distance = 2
+            else
+                coords = shared.target and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+                distance = coords and shared.target and right.zones[data.index].distance or 2
+            end
+
+            right = {
+                type = 'crafting',
+                id = data.id,
+                label = right.label or locale('crafting_bench'),
+                index = data.index,
+                slots = right.slots,
+                items = right.items,
+                coords = coords,
+                distance = distance
+            }
+        end
+    elseif invOpen ~= nil then
+        if inv == 'policeevidence' then
+            if not data then
+                local input = lib.inputDialog(locale('police_evidence'), {
+                    { label = locale('locker_number'), type = 'number', required = true, icon = 'calculator' }
+                }) --[[@as number[]? ]]
+
+                if not input then return end
+
+                data = input[1]
+            end
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+    end
+
+    if accessError then
+        return lib.notify({ id = accessError, type = 'error', description = locale(accessError) })
+    end
+
+    -- Stash does not exist
+    if not left then
+        if left == false then return false end
+
+        if invOpen == false then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+
+        if invOpen then return client.closeInventory() end
+    end
+
+
+    if not cache.vehicle then
+        if inv == 'player' then
+            Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+        elseif inv ~= 'trunk' then
+            Utils.PlayAnim(0, 'pickup_object', 'putdown_low', 5.0, 1.5, 1000, 48, 0.0, 0, 0, 0)
+        end
+    end
+
+    plyState.invOpen = true
+
+    SetInterval(client.interval, 100)
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+    closeTrunk()
+
+    if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+    currentInventory = right or defaultInventory
+    left.items = PlayerData.inventory
+    left.groups = PlayerData.groups
+
+    SendNUIMessage({
+        action = 'setupInventory',
+        data = {
+            leftInventory = left,
+            rightInventory = currentInventory
+        }
+    })
+
+    if not currentInventory.coords and not inv == 'container' then
+        currentInventory.coords = GetEntityCoords(playerPed)
+    end
+
+    if inv == 'trunk' then
+        SetTimeout(200, function()
+            ---@todo animation for vans?
+            Utils.PlayAnim(0, 'anim@heists@prison_heiststation@cop_reactions', 'cop_b_idle', 3.0, 3.0, -1, 49, 0.0, 0, 0, 0)
+
+            local entity = data.entity or NetworkGetEntityFromNetworkId(data.netid)
+            currentInventory.entity = entity
+            currentInventory.door = data.door
+
+            if not currentInventory.door then
+                local vehicleHash = GetEntityModel(entity)
+                local vehicleClass = GetVehicleClass(entity)
+                currentInventory.door = vehicleClass == 12 and { 2, 3 } or Vehicles.Storage[vehicleHash] and 4 or 5
+            end
+
+            while currentInventory?.entity == entity and invOpen and DoesEntityExist(entity) and Inventory.CanAccessTrunk(entity) do
+                Wait(100)
+            end
+
+            if invOpen then client.closeInventory() end
+        end)
+    end
+
+    return true
+end
+
+RegisterNetEvent('ox_inventory:openInventory', client.openInventory)
+exports('openInventory', client.openInventory)
+
+RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+local Animations = lib.load('data.animations')
+local Items = require 'modules.items.client'
+local usingItem = false
+
+---@param data { name: string, label: string, count: number, slot: number, metadata: table<string, any>, weight: number }
+lib.callback.register('ox_inventory:usingItem', function(data, noAnim)
+	local item = Items[data.name]
+
+	if item and usingItem then
+		if not item.client then return true end
+		---@cast item +OxClientProps
+		item = item.client
+
+		if type(item.anim) == 'string' then
+			item.anim = Animations.anim[item.anim]
+		end
+
+		if item.prop then
+			if item.prop[1] then
+				for i = 1, #item.prop do
+					if type(item.prop) == 'string' then
+						item.prop = Animations.prop[item.prop[i]]
+					end
+				end
+			elseif type(item.prop) == 'string' then
+				item.prop = Animations.prop[item.prop]
+			end
+		end
+
+		if not item.disable then
+			item.disable = { combat = true }
+		elseif item.disable.combat == nil then
+			-- Backwards compatibility; you probably don't want people shooting while eating and bandaging anyway
+			item.disable.combat = true
+		end
+
+		local success = (not item.usetime or noAnim or lib.progressBar({
+			duration = item.usetime,
+			label = item.label or locale('using', data.metadata.label or data.label),
+			useWhileDead = item.useWhileDead,
+			canCancel = item.cancel,
+			disable = item.disable,
+			anim = item.anim or item.scenario,
+			prop = item.prop --[[@as ProgressProps]]
+		})) and not PlayerData.dead
+
+		if success then
+			if item.notification then
+				lib.notify({ description = item.notification })
+			end
+
+			if item.status then
+				if client.setPlayerStatus then
+					client.setPlayerStatus(item.status)
+				end
+			end
+
+			return true
+		end
+	end
+end)
+
+local function canUseItem(isAmmo)
+	local ped = cache.ped
+
+	return not usingItem
+    and (not isAmmo or currentWeapon)
+	and PlayerData.loaded
+	and not PlayerData.dead
+	and not invBusy
+	and not lib.progressActive()
+	and not IsPedRagdoll(ped)
+	and not IsPedFalling(ped)
+    and not IsPedShooting(playerPed)
+end
+
+---@param data table
+---@param cb fun(response: SlotWithItem | false)?
+---@param noAnim? boolean
+local function useItem(data, cb, noAnim)
+	local slotData, result = PlayerData.inventory[data.slot]
+
+	if not slotData or not canUseItem(data.ammo and true) then
+        if currentWeapon then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        return
+    end
+
+	if currentWeapon and currentWeapon.timer ~= 0 then
+        if not currentWeapon.timer or currentWeapon.timer - GetGameTimer() > 100 then return end
+
+        DisablePlayerFiring(cache.playerId, true)
+    end
+
+    if invOpen and data.close then client.closeInventory() end
+
+    usingItem = true
+    ---@type boolean?
+    result = lib.callback.await('ox_inventory:useItem', 200, data.name, data.slot, slotData.metadata, noAnim)
+
+	if result and cb then
+		local success, response = pcall(cb, result and slotData)
+
+		if not success and response then
+			warn(('^1An error occurred while calling item "%s" callback!\n^1SCRIPT ERROR: %s^0'):format(slotData.name, response))
+		end
+	end
+
+    if result then
+        TriggerEvent('ox_inventory:usedItem', slotData.name, slotData.slot, next(slotData.metadata) and slotData.metadata)
+    end
+
+	Wait(500)
+    usingItem = false
+end
+
+AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+end)
+
+AddEventHandler('ox_inventory:item', useItem)
+exports('useItem', useItem)
+
+---@param slot number
+---@return boolean?
+local function useSlot(slot, noAnim, dings) --dings added by Holger
+	local item = PlayerData.inventory[slot]
+	if not item then return end
+
+	local data = Items[item.name]
+	if not data then return end
+
+	if canUseItem(data.ammo and true) then
+		if data.component and not currentWeapon then
+			return lib.notify({ id = 'weapon_hand_required', type = 'error', description = locale('weapon_hand_required') })
+		end
+
+		local durability = item.metadata.durability --[[@as number?]]
+		local consume = data.consume --[[@as number?]]
+		local label = item.metadata.label or item.label --[[@as string]]
+
+		-- Naive durability check to get an early exit
+		-- People often don't call the 'useItem' export and then complain about "broken" items being usable
+		-- This won't work with degradation since we need access to os.time on the server
+		if durability and durability <= 100 and consume then
+			if durability <= 0 then
+				return lib.notify({ type = 'error', description = locale('no_durability', label) })
+			elseif consume ~= 0 and consume < 1 and durability < consume * 100 then
+				return lib.notify({ type = 'error', description = locale('not_enough_durability', label) })
+			end
+		end
+
+		data.slot = slot
+
+		if item.metadata.container then
+			return client.openInventory('container', item.slot)
+		elseif data.client then
+			if invOpen and data.close then client.closeInventory() end
+
+			if data.export then
+				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
+				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			end
+		end
+
+		if data.effect then
+			data:effect({name = item.name, slot = item.slot, metadata = item.metadata})
+		elseif data.weapon then
+
+					
+					
+		-----------------HOLGERS Anpassungen------------------
+		if not plyState.canUseWeapons then 
+			return 
+		elseif EnableWeaponWheel  then
+
+			if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+			if currentWeapon then
+				local weaponSlot = currentWeapon.slot
+
+				if dings then
+					
+					currentWeapon =  Weapon.Disarm(currentWeapon,false,true)
+				else						
+					currentWeapon =  Weapon.Disarm(currentWeapon)
+				end
+
+				if weaponSlot == data.slot then return end
+			end
+			GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+			SetCurrentPedWeapon(playerPed, data.hash, false)
+
+			if data.hash ~= GetSelectedPedWeapon(playerPed) then
+				return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+			end
+
+			RemoveWeaponFromPed(cache.ped, data.hash)
+
+			useItem(data, function(result)
+				if result then
+					local sleep
+					currentWeapon, sleep = Weapon.Equip(item, data)
+					if sleep then Wait(sleep) end
+				end
+			end)
+		else
+			if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+			if currentWeapon then
+				local weaponSlot = currentWeapon.slot
+				currentWeapon = Weapon.Disarm(currentWeapon)
+
+				if weaponSlot == data.slot then return end
+			end
+
+			GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+			SetCurrentPedWeapon(playerPed, data.hash, false)
+
+			if data.hash ~= GetSelectedPedWeapon(playerPed) then
+                lib.print.info(('%s cannot be used in current context (default game behaviour)'):format(item.name))
+                return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+			end
+			RemoveWeaponFromPed(cache.ped, data.hash)
+
+			useItem(data, function(result)
+				if result then
+					local sleep
+					currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+					if sleep then Wait(sleep) end
+				end
+			end, noAnim)
+		end
+
+
+		-----------------HOLGERS Anpassungen bis hier------------------			
+		elseif currentWeapon then
+			if data.ammo then
+				if Utils.Waffensyncaus or currentWeapon.metadata.durability <= 0 then return end ----Holger replaced : EnableWeaponWheel to Utils.Waffensyncaus
+
+				local clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+				local currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+				local _, maxAmmo = GetMaxAmmo(playerPed, currentWeapon.hash)
+
+				if maxAmmo < clipSize then clipSize = maxAmmo end
+
+				if currentAmmo == clipSize then return end
+
+				useItem(data, function(resp)
+					if not resp or resp.name ~= currentWeapon?.ammo then return end
+
+					if currentWeapon.metadata.specialAmmo ~= resp.metadata.type and type(currentWeapon.metadata.specialAmmo) == 'string' then
+						local clipComponentKey = ('%s_CLIP'):format(Items[currentWeapon.name].model:gsub('WEAPON_', 'COMPONENT_'))
+						local specialClip = ('%s_%s'):format(clipComponentKey, (resp.metadata.type or currentWeapon.metadata.specialAmmo):upper())
+
+						if type(resp.metadata.type) == 'string' then
+							if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+								if not DoesWeaponTakeWeaponComponent(currentWeapon.hash, specialClip) then
+									warn('cannot use clip with this weapon')
+									return
+								end
+
+								local defaultClip = ('%s_01'):format(clipComponentKey)
+
+								if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, defaultClip) then
+									warn('cannot use clip with currently equipped clip')
+									return
+								end
+
+								if currentAmmo > 0 then
+									warn('cannot mix special ammo with base ammo')
+									return
+								end
+
+								currentWeapon.metadata.specialAmmo = resp.metadata.type
+
+								GiveWeaponComponentToPed(playerPed, currentWeapon.hash, specialClip)
+							end
+						elseif HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+							if currentAmmo > 0 then
+								warn('cannot mix special ammo with base ammo')
+								return
+							end
+
+							currentWeapon.metadata.specialAmmo = nil
+
+							RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, specialClip)
+						end
+					end
+
+					if maxAmmo > clipSize then
+						clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+					end
+
+					currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+					local missingAmmo = clipSize - currentAmmo
+					local addAmmo = resp.count > missingAmmo and missingAmmo or resp.count
+					local newAmmo = currentAmmo + addAmmo
+
+					if newAmmo == currentAmmo then return end
+
+                    AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
+
+					if cache.vehicle then
+						if cache.seat > -1 or IsVehicleStopped(cache.vehicle) then
+							TaskReloadWeapon(playerPed, true)
+                        else
+                            -- This is a hacky solution for forcing ammo to properly load into the
+                            -- weapon clip while driving; without it, ammo will be added but won't
+                            -- load until the player stops doing anything. i.e. if you keep shooting,
+                            -- the weapon will not reload until the clip empties.
+                            -- And yes - for some reason RefillAmmoInstantly needs to run in a loop.
+                            lib.waitFor(function()
+                                RefillAmmoInstantly(playerPed)
+
+                                local _, ammo = GetAmmoInClip(playerPed, currentWeapon.hash)
+                                return ammo == newAmmo or nil
+                            end)
+                        end
+					else
+						Wait(100)
+						MakePedReload(playerPed)
+
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
+					end
+
+					lib.callback.await('ox_inventory:updateWeapon', false, 'load', newAmmo, false, currentWeapon.metadata.specialAmmo)
+				end)
+			elseif data.component then
+				local components = data.client.component
+
+                if not components then return end
+
+				local componentType = data.type
+				local weaponComponents = PlayerData.inventory[currentWeapon.slot].metadata.components
+
+				-- Checks if the weapon already has the same component type attached
+				for componentIndex = 1, #weaponComponents do
+					if componentType == Items[weaponComponents[componentIndex]].type then
+						return lib.notify({ id = 'component_slot_occupied', type = 'error', description = locale('component_slot_occupied', componentType) })
+					end
+				end
+
+				for i = 1, #components do
+					local component = components[i]
+
+					if DoesWeaponTakeWeaponComponent(currentWeapon.hash, component) then
+						if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+							lib.notify({ id = 'component_has', type = 'error', description = locale('component_has', label) })
+						else
+							useItem(data, function(data)
+								if data then
+									local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', tostring(data.slot), currentWeapon.slot)
+
+									if success then
+										GiveWeaponComponentToPed(playerPed, currentWeapon.hash, component)
+										TriggerEvent('ox_inventory:updateWeaponComponent', 'added', component, data.name)
+									end
+								end
+							end)
+						end
+						return
+					end
+				end
+				lib.notify({ id = 'component_invalid', type = 'error', description = locale('component_invalid', label) })
+			elseif data.allowArmed then
+				useItem(data)
+            else
+                return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+			end
+		elseif not data.ammo and not data.component then
+			useItem(data)
+		end
+    end
+end
+exports('useSlot', useSlot)
+
+---@param id number
+---@param slot number
+local function useButton(id, slot)
+	if PlayerData.loaded and not invBusy and not lib.progressActive() then
+		local item = PlayerData.inventory[slot]
+		if not item then return end
+
+		local data = Items[item.name]
+		local buttons = data?.buttons
+
+		if buttons and buttons[id]?.action then
+			buttons[id].action(slot)
+		end
+	end
+end
+
+local function openNearbyInventory() client.openInventory('player') end
+
+exports('openNearbyInventory', openNearbyInventory)
+
+local currentInstance
+local playerCoords
+local Shops = require 'modules.shops.client'
+
+---@todo remove or replace when the bridge module gets restructured
+function OnPlayerData(key, val)
+	if key ~= 'groups' and key ~= 'ped' and key ~= 'dead' then return end
+
+	if key == 'groups' then
+		Inventory.Stashes()
+		Inventory.Evidence()
+		Shops.refreshShops()
+	elseif key == 'dead' and val then
+		currentWeapon = Weapon.Disarm(currentWeapon)
+		client.closeInventory()
+	end
+
+	Utils.WeaponWheel()
+end
+
+-- People consistently ignore errors when one of the "modules" failed to load
+if not Utils or not Weapon or not Items or not Inventory then return end
+
+local invHotkeys = false
+
+---@type function?
+local function registerCommands()
+	RegisterCommand('steal', openNearbyInventory, false)
+
+	local function openGlovebox(vehicle)
+		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end
+
+		local vehicleHash = GetEntityModel(vehicle)
+		local vehicleClass = GetVehicleClass(vehicle)
+		local checkVehicle = Vehicles.Storage[vehicleHash]
+
+		-- No storage or no glovebox
+		if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
+
+		local isOpen = client.openInventory('glovebox', { id = 'glove'..GetVehicleNumberPlateText(vehicle), netid = NetworkGetNetworkIdFromEntity(vehicle) })
+
+		if isOpen then
+			currentInventory.entity = vehicle
+		end
+	end
+
+	local primary = lib.addKeybind({
+		name = 'inv',
+		description = locale('open_player_inventory'),
+		defaultKey = client.keys[1],
+		onPressed = function()
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local closest = lib.points.getClosestPoint()
+
+			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
+				if closest.inv == 'crafting' then
+					return client.openInventory('crafting', { id = closest.id, index = closest.index })
+				elseif closest.inv ~= 'license' and closest.inv ~= 'policeevidence' then
+					return client.openInventory(closest.inv or 'drop', { id = closest.invId, type = closest.type })
+				end
+			end
+
+			return client.openInventory()
+		end
+	})
+
+	lib.addKeybind({
+		name = 'inv2',
+		description = locale('open_secondary_inventory'),
+		defaultKey = client.keys[2],
+		onPressed = function(self)
+            if primary:getCurrentKey() == self:getCurrentKey() then
+                return warn(("secondary inventory keybind '%s' disabled (keybind cannot match primary inventory keybind)"):format(self:getCurrentKey()))
+            end
+
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if invBusy or not canOpenInventory() then
+				return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+			end
+
+			if StashTarget then
+				return client.openInventory('stash', StashTarget)
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local entity, entityType = Utils.Raycast(2|16)
+
+			if not entity then return end
+
+			if not shared.target and entityType == 3 then
+				local model = GetEntityModel(entity)
+
+				if Inventory.Dumpsters[model] then
+					return Inventory.OpenDumpster(entity)
+				end
+			end
+
+			if entityType ~= 2 then return end
+
+			Inventory.OpenTrunk(entity)
+		end
+	})
+
+	lib.addKeybind({
+		name = 'reloadweapon',
+		description = locale('reload_weapon'),
+		defaultKey = 'r',
+		onPressed = function(self)
+			if not currentWeapon or Utils.Waffensyncaus or not canUseItem(true) then return end ---Holger changed   EnableWeaponWheel  to Utils.Waffensyncaus
+
+			if currentWeapon.ammo then
+				if currentWeapon.metadata.durability > 0 then
+					local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+					if slotId then
+						useSlot(slotId)
+					end
+				else
+					lib.notify({ id = 'no_durability', type = 'error', description = locale('no_durability', currentWeapon.label) })
+				end
+			end
+		end
+	})
+
+	lib.addKeybind({
+		name = 'hotbar',
+		description = locale('disable_hotbar'),
+		defaultKey = client.keys[3],
+		onPressed = function()
+			if (EnableWeaponWheel and not HotbarundWeaponWheel) or IsNuiFocused() or lib.progressActive() then return end	--Holger added: and not HotbarundWeaponWheel
+			SendNUIMessage({ action = 'toggleHotbar' })
+		end
+	})
+
+	for i = 1, 5 do
+		lib.addKeybind({
+			name = ('hotkey%s'):format(i),
+			description = locale('use_hotbar', i),
+			defaultKey = tostring(i),
+			onPressed = function()
+				if invOpen or (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() then return end --Holger added: and not HotbarundWeaponWheel
+				useSlot(i)
+			end
+		})
+	end
+
+	registerCommands = nil
+end
+
+function client.closeInventory(server)
+	-- because somehow people are triggering this when the inventory isn't loaded
+	-- and they're incapable of debugging, and I can't repro on a fresh install
+	if not client.interval then return end
+
+	if invOpen then
+		invOpen = nil
+		SetNuiFocus(false, false)
+		SetNuiFocusKeepInput(false)
+		TriggerScreenblurFadeOut(0)
+		closeTrunk()
+		SendNUIMessage({ action = 'closeInventory' })
+		SetInterval(client.interval, 200)
+		Wait(200)
+
+		if invOpen ~= nil then return end
+
+		if not server and currentInventory then
+			TriggerServerEvent('ox_inventory:closeInventory')
+		end
+
+		currentInventory = nil
+		plyState.invOpen = false
+		defaultInventory.coords = nil
+	end
+end
+
+RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
+exports('closeInventory', client.closeInventory)
+
+---@param data updateSlot[]
+---@param weight number
+local function updateInventory(data, weight)
+	local changes = {}
+    ---@type table<string, number>
+	local itemCount = {}
+
+	for i = 1, #data do
+		local v = data[i]
+
+		if not v.inventory or v.inventory == cache.serverId then
+			v.inventory = 'player'
+			local item = v.item
+
+			if currentWeapon?.slot == item?.slot then
+                if item.metadata then
+				    currentWeapon.metadata = item.metadata
+				    TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
+                else
+                    currentWeapon = Weapon.Disarm(currentWeapon, true)
+                end
+			end
+
+			local curItem = PlayerData.inventory[item.slot]
+
+			if curItem and curItem.name then
+				if itemCount[curItem.name] == nil then
+					itemCount[curItem.name] = {}
+				end
+				itemCount[curItem.name].count = (itemCount[curItem.name].count or 0) - curItem.count
+				if not itemCount[curItem.name]?.slot then
+					itemCount[curItem.name].slot = curItem.slot
+				end
+			end
+
+			if item.count then				
+				if itemCount[item.name] == nil then
+					itemCount[item.name] = {}
+				end
+				itemCount[item.name].count = (itemCount[item.name].count or 0) + item.count
+				itemCount[item.name].slot = item.slot
+			end
+
+			changes[item.slot] = item.count and item or false
+			if not item.count then item.name = nil end
+			PlayerData.inventory[item.slot] = item.name and item or nil
+		end
+	end
+
+	SendNUIMessage({ action = 'refreshSlots', data = { items = data, itemCount = itemCount} })
+
+    if weight ~= PlayerData.weight then client.setPlayerData('weight', weight) end
+
+	for itemName, dings in pairs(itemCount) do		--changed count to dings  	Holger
+		local item = Items(itemName)
+
+        if item then
+            item.count += dings.count		--added dings. 	Holger
+
+			------------Holgers Anpassungen
+			if string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN"  and item.count  >0 and not HasPedGotWeapon(cache.ped,item.name,false) then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash] = {}
+				Waffencache[hash].name = item.name
+				Waffencache[hash].slot = dings.slot
+				Waffencache[hash].hash = hash
+				
+				RemoveWeaponFromPed(cache.ped,item.name)
+				GiveWeaponToPed(cache.ped,item.name,1,false,false) 
+			elseif string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN" and dings.count  == 0 then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash].slot = dings.slot
+			end
+
+			-----Holgers Anpassungen ende
+			---
+            TriggerEvent('ox_inventory:itemCount', item.name, item.count)
+
+            if dings.count < 0 then		--added dings.	Holger
+
+				
+				if string.sub(item.name,1,7) =="WEAPON_" then 
+					Utils.WeaponWheelsyncen()
+				end
+				
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:removeInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.remove then
+                    item.client.remove(item.count)
+                end
+            elseif dings.count > 0 then	--added dings. 	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:addInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.add then
+                    item.client.add(item.count)
+                end
+            end
+        end
+	end
+
+	client.setPlayerData('inventory', PlayerData.inventory)
+	TriggerEvent('ox_inventory:updateInventory', changes)
+end
+
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
+	if source ~= '' and next(items) then updateInventory(items, weights) end
+end)
+
+RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
+	if source == '' then return end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	lib.notify({ description = locale('items_returned') })
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for _, slotData in pairs(data[1]) do
+		num += 1
+		items[num] = { item = slotData, inventory = cache.serverId }
+	end
+
+	updateInventory(items, data[3])
+end)
+
+RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
+	if source == '' then return end
+	if message then lib.notify({ description = locale('items_confiscated') }) end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for slot in pairs(PlayerData.inventory) do
+		num += 1
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
+	end
+
+	updateInventory(items, 0)
+end)
+
+
+---@param point CPoint
+local function nearbyDrop(point)
+	if not point.instance or point.instance == currentInstance then
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 150, 30, 30, 222, false, false, 0, true, false, false, false)
+	end
+end
+
+---@param point CPoint
+local function onEnterDrop(point)
+	if not point.instance or point.instance == currentInstance and not point.entity then
+		local model = point.model or client.dropmodel
+
+        -- Prevent breaking inventory on invalid point.model instead use default client.dropmodel
+        if not IsModelValid(model) and not IsModelInCdimage(model) then
+            model = client.dropmodel
+        end
+		lib.requestModel(model)
+
+		local entity = CreateObject(model, point.coords.x, point.coords.y, point.coords.z, false, true, true)
+
+		SetModelAsNoLongerNeeded(model)
+		PlaceObjectOnGroundProperly(entity)
+		FreezeEntityPosition(entity, true)
+		SetEntityCollision(entity, false, true)
+
+		point.entity = entity
+	end
+end
+
+local function onExitDrop(point)
+	local entity = point.entity
+
+	if entity then
+		Utils.DeleteEntity(entity)
+		point.entity = nil
+	end
+end
+
+local function createDrop(dropId, data)
+	local point = lib.points.new({
+		coords = data.coords,
+		distance = 16,
+		invId = dropId,
+		instance = data.instance,
+		model = data.model
+	})
+
+	if point.model or client.dropprops then
+		point.distance = 30
+		point.onEnter = onEnterDrop
+		point.onExit = onExitDrop
+	else
+		point.nearby = nearbyDrop
+	end
+
+	client.drops[dropId] = point
+end
+
+RegisterNetEvent('ox_inventory:createDrop', function(dropId, data, owner, slot)
+	if client.drops then
+		createDrop(dropId, data)
+	end
+
+	if owner == cache.serverId then
+		if currentWeapon?.slot == slot then
+			currentWeapon = Weapon.Disarm(currentWeapon)
+		end
+
+		if invOpen and #(GetEntityCoords(playerPed) - data.coords) <= 1 then
+			if not cache.vehicle then
+				client.openInventory('drop', dropId)
+			else
+				SendNUIMessage({
+					action = 'setupInventory',
+					data = { rightInventory = currentInventory }
+				})
+			end
+		end
+	end
+end)
+
+RegisterNetEvent('ox_inventory:removeDrop', function(dropId)
+	if client.drops then
+		local point = client.drops[dropId]
+
+		if point then
+			client.drops[dropId] = nil
+			point:remove()
+
+			if point.entity then Utils.DeleteEntity(point.entity) end
+		end
+	end
+end)
+
+---@type function?
+local function setStateBagHandler(stateId)
+	AddStateBagChangeHandler('invOpen', stateId, function(_, _, value)
+		invOpen = value
+	end)
+
+	AddStateBagChangeHandler('invBusy', stateId, function(_, _, value)
+		invBusy = value
+	end)
+
+    AddStateBagChangeHandler('canUseWeapons', stateId, function(_, _, value)
+        if not value and currentWeapon then
+            currentWeapon = Weapon.Disarm(currentWeapon)
+        end
+    end)
+
+	AddStateBagChangeHandler('instance', stateId, function(_, _, value)
+		currentInstance = value
+
+		if client.drops then
+			-- Iterate over known drops and remove any points in a different instance (ignoring no instance)
+			for dropId, point in pairs(client.drops) do
+				if point.instance then
+					if point.instance ~= value then
+						if point.entity then
+							Utils.DeleteEntity(point.entity)
+							point.entity = nil
+						end
+
+						point:remove()
+					else
+						-- Recreate the drop using data from the old point
+						createDrop(dropId, point)
+					end
+				end
+			end
+		end
+	end)
+
+	AddStateBagChangeHandler('dead', stateId, function(_, _, value)
+		Utils.WeaponWheel()
+		PlayerData.dead = value
+	end)
+
+	AddStateBagChangeHandler('invHotkeys', stateId, function(_, _, value)
+		invHotkeys = value
+	end)
+
+	setStateBagHandler = nil
+end
+
+local waraus = false		--Holger added
+
+lib.onCache('seat', function(seat)
+	--Holgers part start
+	if currentWeapon then
+		Weapon.Disarm(currentWeapon,true)
+	end
+	Utils.ClearWeapons()
+	Utils.WeaponWheelsyncen()
+	--Holgers part stop
+	if seat then
+		local hasWeapon = GetCurrentPedVehicleWeapon(cache.ped)
+
+		if hasWeapon and not EnableWeaponWheel then  	--Holger added and not EnableWeaponWheel 
+			waraus = true								--Holger added
+			return Utils.WeaponWheel(true)
+		end
+	end
+	if waraus then --Holger added
+		Utils.WeaponWheel(false)
+		waraus = false	--Holger added
+	end		--Holger added
+end)
+
+lib.onCache('vehicle', function()
+	if invOpen and (not currentInventory.entity or currentInventory.entity == cache.vehicle) then
+		return client.closeInventory()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inventory, weight, player)
+	if source == '' then return end
+
+    ---@class PlayerData
+    ---@field inventory table<number, SlotWithItem?>
+    ---@field weight number
+	PlayerData = player
+	PlayerData.id = cache.playerId
+	PlayerData.source = cache.serverId
+    PlayerData.maxWeight = shared.playerweight
+
+	setmetatable(PlayerData, {
+		__index = function(self, key)
+			if key == 'ped' then
+				return PlayerPedId()
+			end
+		end
+	})
+
+	if setStateBagHandler then setStateBagHandler(('player:%s'):format(cache.serverId)) end
+
+	local ItemData = table.create(0, #Items)
+
+	for _, v in pairs(Items --[[@as table<string, OxClientItem>]]) do
+		local buttons = v.buttons and {} or nil
+
+		if buttons then
+			for i = 1, #v.buttons do
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
+			end
+		end
+
+		ItemData[v.name] = {
+			label = v.label,
+			stack = v.stack,
+			close = v.close,
+			count = 0,
+			description = v.description,
+			buttons = buttons,
+			ammoName = v.ammoname,
+			image = v.client?.image
+		}
+	end
+
+	for _, data in pairs(inventory) do
+		local item = Items[data.name]
+
+		if item then
+			item.count += data.count
+			ItemData[data.name].count += data.count
+			local add = item.client?.add
+
+			if add then
+				add(item.count)
+			end
+		end
+	end
+
+	local phone = Items.phone
+
+	if phone and phone.count < 1 then
+		pcall(function()
+			return exports.npwd:setPhoneDisabled(true)
+		end)
+	end
+
+	client.setPlayerData('inventory', inventory)
+	client.setPlayerData('weight', weight)
+	currentWeapon = nil
+	Weapon.ClearAll()
+
+	local uiLocales = {}
+	local locales = lib.getLocales()
+
+	for k, v in pairs(locales) do
+		if k:find('^ui_')then
+			uiLocales[k] = v
+		end
+	end
+
+	uiLocales['$'] = locales['$']
+	uiLocales.ammo_type = locales.ammo_type
+
+	client.drops = currentDrops
+
+	for dropId, data in pairs(currentDrops) do
+		createDrop(dropId, data)
+	end
+
+	local hasTextUi
+	local uiOptions = { icon = 'fa-id-card' }
+
+	---@param point CPoint
+	local function nearbyLicense(point)
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, 0, true, false, false, false)
+
+		if point.isClosest and point.currentDistance < 1.2 then
+			if not hasTextUi then
+				hasTextUi = point
+				lib.showTextUI(point.message, uiOptions)
+			end
+
+			if IsControlJustReleased(0, 38) then
+				lib.callback('ox_inventory:buyLicense', 1000, function(success, message)
+					if success ~= nil then
+						lib.notify({
+							id = message,
+							type = success == false and 'error' or 'success',
+							description = locale(message, locale('license', point.type:gsub("^%l", string.upper)))
+						})
+					end
+				end, point.invId)
+			end
+		elseif hasTextUi == point then
+			hasTextUi = false
+			lib.hideTextUI()
+		end
+	end
+
+	for id, data in pairs(lib.load('data.licenses')) do
+		lib.points.new({
+			coords = data.coords,
+			distance = 16,
+			inv = 'license',
+			type = data.name,
+			price = data.price,
+			invId = id,
+			nearby = nearbyLicense,
+			message = ('**%s**  \n%s'):format(locale('purchase_license', data.name), locale('interact_prompt', GetControlInstructionalButton(0, 38, true):sub(3)))
+		})
+	end
+
+	while not client.uiLoaded do Wait(50) end
+
+	SendNUIMessage({
+		action = 'init',
+		data = {
+			locale = uiLocales,
+			items = ItemData,
+			leftInventory = {
+				id = cache.playerId,
+				slots = shared.playerslots,
+				items = PlayerData.inventory,
+				maxWeight = shared.playerweight,
+			},
+			imagepath = client.imagepath
+		}
+	})
+
+	PlayerData.loaded = true
+
+	lib.notify({ description = locale('inventory_setup') })
+	Shops.refreshShops()
+	Inventory.Stashes()
+	Inventory.Evidence()
+
+	if registerCommands then registerCommands() end
+
+	TriggerEvent('ox_inventory:updateInventory', PlayerData.inventory)
+
+	client.interval = SetInterval(function()
+		if invOpen == false then
+			playerCoords = GetEntityCoords(playerPed)
+
+			if currentWeapon and IsPedUsingActionMode(playerPed) then
+				SetPedUsingActionMode(playerPed, false, -1, 'DEFAULT_ACTION')
+			end
+
+		elseif invOpen == true then
+			if not canOpenInventory() then
+				client.closeInventory()
+			else
+				playerCoords = GetEntityCoords(playerPed)
+
+				if currentInventory and not currentInventory.ignoreSecurityChecks then
+                    local maxDistance = (currentInventory.distance or currentInventory.type == 'stash' and 4.8 or 1.8) + 0.2
+
+					if currentInventory.type == 'otherplayer' then
+						local id = GetPlayerFromServerId(currentInventory.id)
+						local ped = GetPlayerPed(id)
+						local pedCoords = GetEntityCoords(ped)
+
+						if not id or #(playerCoords - pedCoords) > maxDistance or not (client.hasGroup(shared.police) or canOpenTarget(ped)) then
+							client.closeInventory()
+							lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+						else
+							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
+						end
+
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > maxDistance or canOpenTarget(playerPed)) then
+						client.closeInventory()
+						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+					end
+				end
+			end
+		end
+
+		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
+			Utils.DeleteEntity(client.parachute[1])
+			client.parachute = false
+		end
+
+		--[[ if EnableWeaponWheel then return end
+
+		local weaponHash = GetSelectedPedWeapon(playerPed)
+
+		if currentWeapon then
+			if weaponHash ~= currentWeapon.hash and currentWeapon.timer then
+				local weaponCount = Items[currentWeapon.name]?.count
+
+				if weaponCount > 0 then
+					SetCurrentPedWeapon(playerPed, currentWeapon.hash, true)
+					SetAmmoInClip(playerPed, currentWeapon.hash, currentWeapon.metadata.ammo)
+					SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+
+					weaponHash = GetSelectedPedWeapon(playerPed)
+				end
+
+				if weaponHash ~= currentWeapon.hash then
+                    lib.print.info(('%s cannot be used in current context (default game behaviour)'):format(currentWeapon.name))
+					currentWeapon = Weapon.Disarm(currentWeapon, true)
+				end
+			end
+		elseif client.weaponmismatch and not client.ignoreweapons[weaponHash] then
+			local weaponType = GetWeapontypeGroup(weaponHash)
+
+			if weaponType ~= 0 and weaponType ~= `GROUP_UNARMED` then
+				Weapon.Disarm(currentWeapon, true)
+			end
+		end ]]		--disabled by Holger
+	end, 200)
+
+	local playerId = cache.playerId
+	local EnableKeys = client.enablekeys
+	local DisablePlayerVehicleRewards = DisablePlayerVehicleRewards
+	local DisableAllControlActions = DisableAllControlActions
+	local HideHudAndRadarThisFrame = HideHudAndRadarThisFrame
+	local EnableControlAction = EnableControlAction
+	local DisablePlayerFiring = DisablePlayerFiring
+	local HudWeaponWheelIgnoreSelection = HudWeaponWheelIgnoreSelection
+	local DisableControlAction = DisableControlAction
+	local IsPedShooting = IsPedShooting
+	local IsControlJustReleased = IsControlJustReleased
+	local IsControlPressed = IsControlPressed		--added by Holger
+	local IsDisabledControlPressed = IsDisabledControlPressed		--added by Holger
+	local hotbartasten = {157,158,160,164,165}		--added by Holger
+
+	client.tick = SetInterval(function()
+		DisablePlayerVehicleRewards(playerId)
+		local sleep = 100		--sleep by Holger
+
+		if invOpen then
+			sleep = 0
+			DisableAllControlActions(0)
+			HideHudAndRadarThisFrame()
+
+			for i = 1, #EnableKeys do
+				EnableControlAction(0, EnableKeys[i], true)
+			end
+
+			if currentInventory.type == 'newdrop' then
+				EnableControlAction(0, 30, true)
+				EnableControlAction(0, 31, true)
+			end
+		else
+			if invBusy then
+				DisableControlAction(0, 23, true)
+				DisableControlAction(0, 36, true)
+				sleep = 0
+			end
+
+			if usingItem or invOpen or IsPedCuffed(playerPed) then
+				DisablePlayerFiring(playerId, true)
+				sleep = 0
+			end
+
+			if not EnableWeaponWheel then
+				HudWeaponWheelIgnoreSelection()
+				DisableControlAction(0, 37, true)
+				sleep = 0
+			end
+
+			if HotbarundWeaponWheel then--by Holger
+				sleep = 0
+				for i = 1, #hotbartasten do
+					if IsControlPressed(0, hotbartasten[i]) or IsDisabledControlPressed(0,hotbartasten[i]) then
+						DisableControlAction(0, hotbartasten[i], true)
+					end
+				end
+			end--by Holger
+
+			if currentWeapon and currentWeapon.timer then
+				sleep = 0
+				DisableControlAction(0, 80, true)
+				DisableControlAction(0, 140, true)
+
+				if currentWeapon.metadata.durability <= 0 or not currentWeapon.timer then
+					DisablePlayerFiring(playerId, true)
+				elseif client.aimedfiring and not currentWeapon.melee and currentWeapon.group ~= `GROUP_PETROLCAN` and not IsPlayerFreeAiming(playerId) then
+					DisablePlayerFiring(playerId, true)
+				end
+
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if not invBusy and currentWeapon.timer ~= 0 and currentWeapon.timer < GetGameTimer() then
+					currentWeapon.timer = 0
+
+					if weaponAmmo then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo)
+
+						if client.autoreload and currentWeapon.ammo and GetAmmoInPedWeapon(playerPed, currentWeapon.hash) == 0 then
+							local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+							if slotId then
+								CreateThread(function() useSlot(slotId) end)
+							end
+						end
+
+					elseif currentWeapon.metadata.durability then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'melee', currentWeapon.melee)
+						currentWeapon.melee = 0
+					end
+				elseif weaponAmmo then
+					if IsPedShooting(playerPed) then
+						local currentAmmo
+						local durabilityDrain = Items[currentWeapon.name].durability
+
+						if currentWeapon.group == `GROUP_PETROLCAN` or currentWeapon.group == `GROUP_FIREEXTINGUISHER` then
+							currentAmmo = weaponAmmo - durabilityDrain < 0 and 0 or weaponAmmo - durabilityDrain
+							currentWeapon.metadata.durability = currentAmmo
+							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+
+							if currentAmmo <= 0 then
+								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+							end
+						else
+							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+
+							if currentAmmo < weaponAmmo then
+								currentAmmo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+								currentWeapon.metadata.ammo = currentAmmo
+								currentWeapon.metadata.durability = currentWeapon.metadata.durability - (durabilityDrain * math.abs((weaponAmmo or 0.1) - currentAmmo))
+							end
+						end
+
+						if currentAmmo <= 0 then
+							if cache.vehicle then
+								TaskSwapWeapon(playerPed, true)
+							end
+
+							currentWeapon.timer = GetGameTimer() + 200
+						else currentWeapon.timer = GetGameTimer() + (GetWeaponTimeBetweenShots(currentWeapon.hash) * 1000) + 100 end
+					end
+				elseif currentWeapon.throwable then
+					if not invBusy and IsControlPressed(0, 24) then
+						invBusy = 1
+
+						CreateThread(function()
+							local weapon = currentWeapon
+
+							while currentWeapon and (not IsPedWeaponReadyToShoot(cache.ped) or IsDisabledControlPressed(0, 24)) and GetSelectedPedWeapon(playerPed) == weapon.hash do
+								Wait(0)
+							end
+
+							if GetSelectedPedWeapon(playerPed) == weapon.hash then Wait(700) end
+
+							while IsPedPlantingBomb(playerPed) do Wait(0) end
+
+							TriggerServerEvent('ox_inventory:updateWeapon', 'throw', nil, weapon.slot)
+							plyState:set('invBusy', false, true)
+
+							currentWeapon = nil
+
+							RemoveWeaponFromPed(playerPed, weapon.hash)
+							TriggerEvent('ox_inventory:currentWeapon')
+						end)
+					end
+				elseif currentWeapon.melee and IsControlJustReleased(0, 24) and IsPedPerformingMeleeAction(playerPed) then
+					currentWeapon.melee += 1
+					currentWeapon.timer = GetGameTimer() + 200
+				end
+			end
+		end
+		if sleep > 0 then --- sleep by Holger
+			Wait(sleep)
+		end
+	end)
+
+	plyState:set('invBusy', false, true)
+	plyState:set('invOpen', false, false)
+	plyState:set('invHotkeys', true, false)
+	plyState:set('canUseWeapons', true, false)
+	collectgarbage('collect')
+	Utils.WeaponWheelsyncen()
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if shared.resource == resourceName then
+		client.onLogout()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+    currentInventory.type = 'inspect'
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+RegisterNUICallback('uiLoaded', function(_, cb)
+	client.uiLoaded = true
+	cb(1)
+end)
+
+RegisterNUICallback('getItemData', function(itemName, cb)
+	cb(Items[itemName])
+end)
+
+RegisterNUICallback('removeComponent', function(data, cb)
+	cb(1)
+
+	if not currentWeapon then
+		return TriggerServerEvent('ox_inventory:updateWeapon', 'component', data)
+	end
+
+	if data.slot ~= currentWeapon.slot then
+		return lib.notify({ id = 'weapon_hand_wrong', type = 'error', description = locale('weapon_hand_wrong') })
+	end
+
+	local itemSlot = PlayerData.inventory[currentWeapon.slot]
+
+    if not itemSlot then return end
+
+	for _, component in pairs(Items[data.component].client.component) do
+		if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+			for k, v in pairs(itemSlot.metadata.components) do
+				if v == data.component then
+					local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', k)
+
+					if success then
+						RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, component)
+						TriggerEvent('ox_inventory:updateWeaponComponent', 'removed', component, data.component)
+					end
+
+					break
+				end
+			end
+		end
+	end
+end)
+
+RegisterNUICallback('removeAmmo', function(slot, cb)
+	cb(1)
+	local slotData = PlayerData.inventory[slot]
+
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo == 0 then return end
+
+	local success = lib.callback.await('ox_inventory:removeAmmoFromWeapon', false, slot)
+
+	if success and slot == currentWeapon?.slot then
+		SetPedAmmo(playerPed, currentWeapon.hash, 0)
+	end
+end)
+
+RegisterNUICallback('useItem', function(slot, cb)
+	useSlot(slot --[[@as number]])
+	cb(1)
+end)
+
+local function giveItemToTarget(serverId, slotId, count)
+    if type(slotId) ~= 'number' then return TypeError('slotId', 'number', type(slotId)) end
+    if count and type(count) ~= 'number' then return TypeError('count', 'number', type(count)) end
+
+    if slotId == currentWeapon?.slot then
+        currentWeapon = Weapon.Disarm(currentWeapon)
+    end
+
+    Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 1.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+
+    local notification = lib.callback.await('ox_inventory:giveItem', false, slotId, serverId, count or 0)
+
+    if notification then
+        lib.notify({ type = 'error', description = locale(table.unpack(notification)) })
+    end
+end
+
+exports('giveItemToTarget', giveItemToTarget)
+
+local function isGiveTargetValid(ped, coords)
+    if cache.vehicle and GetVehiclePedIsIn(ped, false) == cache.vehicle then
+        return true
+    end
+
+    local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
+
+    return entity == ped and IsEntityVisible(ped)
+end
+
+RegisterNUICallback('giveItem', function(data, cb)
+	cb(1)
+
+    if usingItem then return end
+
+	if client.giveplayerlist then
+		local nearbyPlayers = lib.getNearbyPlayers(GetEntityCoords(playerPed), 3.0)
+        local nearbyCount = #nearbyPlayers
+
+		if nearbyCount == 0 then return end
+
+        if nearbyCount == 1 then
+			local option = nearbyPlayers[1]
+
+            if not isGiveTargetValid(option.ped, option.coords) then return end
+
+            return giveItemToTarget(GetPlayerServerId(option.id), data.slot, data.count)
+        end
+
+        local giveList, n = {}, 0
+
+		for i = 1, #nearbyPlayers do
+			local option = nearbyPlayers[i]
+
+            if isGiveTargetValid(option.ped, option.coords) then
+				local playerName = GetPlayerName(option.id)
+				option.id = GetPlayerServerId(option.id)
+                ---@diagnostic disable-next-line: inject-field
+				option.label = ('[%s] %s'):format(option.id, playerName)
+				n += 1
+				giveList[n] = option
+			end
+		end
+
+        if n == 0 then return end
+
+		lib.registerMenu({
+			id = 'ox_inventory:givePlayerList',
+			title = 'Give item',
+			options = giveList,
+		}, function(selected)
+            giveItemToTarget(giveList[selected].id, data.slot, data.count)
+        end)
+
+		return lib.showMenu('ox_inventory:givePlayerList')
+	end
+
+    if cache.vehicle then
+		local seats = GetVehicleMaxNumberOfPassengers(cache.vehicle) - 1
+
+		if seats >= 0 then
+			local passenger = GetPedInVehicleSeat(cache.vehicle, cache.seat - 2 * (cache.seat % 2) + 1)
+
+			if passenger ~= 0 and IsEntityVisible(passenger) then
+                return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(passenger)), data.slot, data.count)
+			end
+		end
+
+        return
+	end
+
+    local entity = Utils.Raycast(1|2|4|8|16, GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 3.0, 0.5), 0.2)
+
+    if entity and IsPedAPlayer(entity) and IsEntityVisible(entity) and #(GetEntityCoords(playerPed, true) - GetEntityCoords(entity, true)) < 3.0 then
+        return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(entity)), data.slot, data.count)
+    end
+end)
+
+RegisterNUICallback('useButton', function(data, cb)
+	useButton(data.id, data.slot)
+	cb(1)
+end)
+
+RegisterNUICallback('exit', function(_, cb)
+	client.closeInventory()
+	cb(1)
+end)
+
+lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
+	recipe = CraftingBenches[id].items[recipe]
+
+	return lib.progressCircle({
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
+		duration = recipe.duration or 3000,
+		canCancel = true,
+		disable = {
+			move = true,
+			combat = true,
+		},
+		anim = {
+			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+			clip = 'machinic_loop_mechandplayer',
+		}
+	})
+end)
+
+local swapActive = false
+
+---Synchronise and validate all item movement between the NUI and server.
+RegisterNUICallback('swapItems', function(data, cb)
+    if swapActive or not invOpen or invBusy or usingItem then return cb(false) end
+
+    swapActive = true
+
+	if data.toType == 'newdrop' then
+		if cache.vehicle or IsPedFalling(playerPed) then
+			swapActive = false
+			return cb(false)
+		end
+
+		local coords = GetEntityCoords(playerPed)
+
+		if IsEntityInWater(playerPed) then
+			local destination = vec3(coords.x, coords.y, -200)
+			local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z, 511, cache.ped, 4)
+
+			while true do
+				Wait(0)
+				local retval, hit, endCoords = GetShapeTestResult(handle)
+
+				if retval ~= 1 then
+					if not hit then return end
+
+					data.coords = vec3(endCoords.x, endCoords.y, endCoords.z + 1.0)
+
+					break
+				end
+			end
+		else
+			data.coords = coords
+		end
+    end
+
+	if currentInstance then
+		data.instance = currentInstance
+	end
+
+	if currentWeapon and data.fromType ~= data.toType then
+		if (data.fromType == 'player' and data.fromSlot == currentWeapon.slot) or (data.toType == 'player' and data.toSlot == currentWeapon.slot) then
+			currentWeapon = Weapon.Disarm(currentWeapon, true)
+		end
+	end
+
+	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
+    swapActive = false
+
+	cb(success or false)
+
+	if success then
+        if weaponSlot and currentWeapon then
+            currentWeapon.slot = weaponSlot
+        end
+
+		if response then
+			updateInventory(response.items, response.weight)
+		end
+	elseif response then
+		if type(response) == 'table' then
+			SendNUIMessage({ action = 'refreshSlots', data = { items = response } })
+		else
+			lib.notify({ type = 'error', description = locale(response) })
+		end
+	end
+end)
+
+RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
+	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
+
+	if data then
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
+	end
+
+	if message then
+		lib.notify(message)
+	end
+
+	cb(response)
+end)
+
+RegisterNUICallback('craftItem', function(data, cb)
+	cb(true)
+
+	local id, index = currentInventory.id, currentInventory.index
+
+	for i = 1, data.count do
+		local success, response = lib.callback.await('ox_inventory:craftItem', 200, id, index, data.fromSlot, data.toSlot)
+
+		if not success then
+			if response then lib.notify({ type = 'error', description = locale(response or 'cannot_perform') }) end
+			break
+		end
+	end
+
+	if not currentInventory or currentInventory.type ~= 'crafting' then
+		client.openInventory('crafting', { id = id, index = index })
+	end
+end)
+
+lib.callback.register('ox_inventory:getVehicleData', function(netid)
+	local entity = NetworkGetEntityFromNetworkId(netid)
+
+	if entity then
+		return GetEntityModel(entity), GetVehicleClass(entity)
+	end
+end)
+
+
+
+
+
+-----------------HOLGERS Anpassungen------------------
+CreateThread(function()
+	local hash 
+	while true do
+		if EnableWeaponWheel and not Utils.Waffensyncaus then
+			local  temphash = GetSelectedPedWeapon(cache.ped)
+			if hash ~= temphash then
+				if Waffencache[temphash] then
+					useSlot(Waffencache[temphash].slot,"lurchig",true)
+					Wait(100)
+				else	
+					if temphash ~= -1569615261 and Weapon.WeaponByHash[temphash] then
+						RemoveWeaponFromPed(cache.ped, temphash)
+					elseif currentWeapon then
+						currentWeapon = Weapon.Disarm(currentWeapon,false,true)
+						--Wait(100)
+					end
+				end
+				hash = temphash
+			end
+		elseif Utils.Waffensyncaus then
+			local  temphash = GetSelectedPedWeapon(cache.ped)			
+			if hash ~= temphash then
+				if temphash ~= -1569615261 and hash ~= -1569615261  and Weapon.WeaponByHash[temphash] then
+					Weapon.triggerAnimation(hash,temphash,false)
+					Weapon.triggerAnimation(hash,temphash,true)
+				elseif hash == -1569615261 and temphash ~= -1569615261 and Weapon.WeaponByHash[temphash] then
+					Weapon.triggerAnimation(hash,temphash,true)
+				elseif temphash == -1569615261 then
+					Weapon.triggerAnimation(hash,temphash,false)					
+					GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+				end
+				hash = temphash
+			end
+		else
+			Wait(900)
+		end
+
+		Wait(100)
+	end
+
+end)
+
+
+
+
+
+
+
+-----------------HOLGERS Anpassungen bis hier------------------

--- a/2.42.3/modules/utils/client.lua
+++ b/2.42.3/modules/utils/client.lua
@@ -1,0 +1,256 @@
+if not lib then return end
+
+local Utils = {}
+
+Utils.Waffensyncaus = false     --added by Holger
+
+function Utils.PlayAnim(wait, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(cache.ped, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+                                time)
+    lib.requestAnimDict(dict)
+    TaskPlayAnimAdvanced(cache.ped, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+        time, 0, 0)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+---@param flag number
+---@param destination? vector3
+---@param size? number
+---@return number | false
+---@return number?
+function Utils.Raycast(flag, destination, size)
+    local playerCoords = GetEntityCoords(cache.ped)
+    destination = destination or GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)
+    local rayHandle = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x,
+        destination.y, destination.z, size or 2.2, flag or 30, cache.ped, 4)
+    while true do
+        Wait(0)
+        local result, _, coords, _, entityHit = GetShapeTestResult(rayHandle)
+        if result ~= 1 then
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x, destination.y, destination.z, 0, 0, 255, 255)
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, coords.x, coords.y, coords.z, 255, 0, 0, 255)
+            local entityType
+            if entityHit then entityType = GetEntityType(entityHit) end
+            if entityHit and entityType ~= 0 then
+                return entityHit, entityType
+            end
+            return false
+        end
+    end
+end
+
+function Utils.GetClosestPlayer()
+    local players = GetActivePlayers()
+    local playerCoords = GetEntityCoords(cache.ped)
+    local targetDistance, targetId, targetPed
+
+    for i = 1, #players do
+        local player = players[i]
+
+        if player ~= cache.playerId then
+            local ped = GetPlayerPed(player)
+            local distance = #(playerCoords - GetEntityCoords(ped))
+
+            if distance < (targetDistance or 2) then
+                targetDistance = distance
+                targetId = player
+                targetPed = ped
+            end
+        end
+    end
+
+    return targetId, targetPed
+end
+
+-- Replace ox_inventory notify with ox_lib (backwards compatibility)
+function Utils.Notify(data)
+    data.description = data.text
+    data.text = nil
+    lib.notify(data)
+end
+
+RegisterNetEvent('ox_inventory:notify', Utils.Notify)
+exports('notify', Utils.Notify)
+
+function Utils.ItemNotify(data)
+    if not client.itemnotify then
+        return
+    end
+
+    SendNUIMessage({ action = 'itemNotify', data = data })
+end
+
+RegisterNetEvent('ox_inventory:itemNotify', Utils.ItemNotify)
+
+---@deprecated
+function Utils.DeleteObject(obj)
+    SetEntityAsMissionEntity(obj, false, true)
+    DeleteObject(obj)
+end
+
+function Utils.DeleteEntity(entity)
+    if DoesEntityExist(entity) then
+        SetEntityAsMissionEntity(entity, false, true)
+        DeleteEntity(entity)
+    end
+end
+
+local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
+
+-- Enables the weapon wheel, but disables the use of inventory weapons.
+-- Mostly used for weaponised vehicles, though could be called for "minigames"
+
+EnableWeaponWheel = true        --added by Holger
+SetWeaponsNoAutoswap(true)      --added by Holger
+SetWeaponsNoAutoreload(true)    --added by Holger
+function Utils.WeaponWheel(state)
+    if client.disableweapons then state = true end
+    if state == nil then state = EnableWeaponWheel end
+
+    EnableWeaponWheel = state
+    SetWeaponsNoAutoswap(not state)
+    SetWeaponsNoAutoreload(not state)
+    Utils.WeaponWheelsyncen()       --added by Holger
+
+    if client.suppresspickups then
+        -- CLEAR_PICKUP_REWARD_TYPE_SUPPRESSION | SUPPRESS_PICKUP_REWARD_TYPE
+        return state and N_0x762db2d380b48d04(rewardTypes) or N_0xf92099527db8e2a7(rewardTypes, true)
+    end
+end
+
+--Holgers part starts
+
+
+function Utils.Waffensyncdisable(state)
+	if state == nil then state = Utils.Waffensyncaus end
+	Utils.Waffensyncaus = state
+	Utils.WeaponWheelsyncen()
+end
+
+Utils.WeaponWheelundHotbar = function(state)
+	if state == nil then state = HotbarundWeaponWheel end
+	HotbarundWeaponWheel = state
+	Utils.WeaponWheel(state)
+end
+
+Utils.WeaponWheelsyncen = function ()
+	Utils.ClearWeapons()
+	if not Utils.Waffensyncaus then		
+		Wait(500)
+		local items = exports.ox_inventory:GetPlayerItems()
+		if items ~=nil  then
+			Waffencache = nil
+			Waffencache = {}
+			for k,v in pairs(items) do
+				if string.sub(v.name,1,7) =="WEAPON_"  and v.name ~= "WEAPON_PETROLCAN" then
+					if HasPedGotWeapon(cache.ped,v.name,false) then
+						RemoveWeaponFromPed(cache.ped,v.name)
+					end
+					local hash = GetHashKey(v.name)
+					Waffencache[hash] = {}
+					Waffencache[hash].name = v.name
+					Waffencache[hash].slot = v.slot
+					Waffencache[hash].hash = hash
+
+					GiveWeaponToPed(cache.ped,v.name,1,false,false)
+				end
+			end
+		end
+	end
+end
+
+--Holgers part ends
+
+
+exports('weaponWheel', Utils.WeaponWheel)
+exports('Weaponsyncdisable', Utils.Waffensyncdisable)
+exports('WeaponWheelandHotbar', Utils.WeaponWheelundHotbar)
+
+function Utils.CreateBlip(settings, coords)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, settings.id)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, settings.scale)
+    SetBlipColour(blip, settings.colour)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName(settings.name)
+    EndTextCommandSetBlipName(blip)
+
+    return blip
+end
+
+---Takes OxTargetBoxZone or legacy zone data (PolyZone) and creates a zone.
+---@param data OxTargetBoxZone | { length: number, minZ: number, maxZ: number, loc: vector3, heading: number, width: number, distance: number }
+---@param options? OxTargetOption[]
+---@return number
+function Utils.CreateBoxZone(data, options)
+    if data.length then
+        local height = math.abs(data.maxZ - data.minZ)
+        local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2
+        data.coords = vec3(data.loc.x, data.loc.y, z)
+        data.size = vec3(data.width, data.length, height)
+        data.rotation = data.heading
+        data.loc = nil
+        data.heading = nil
+        data.length = nil
+        data.width = nil
+        data.maxZ = nil
+        data.minZ = nil
+    end
+
+    if not data.options and options then
+        local distance = data.distance or 2.0
+
+        for k, v in pairs(options) do
+            if not v.distance then
+                v.distance = distance
+            end
+        end
+
+        data.options = options
+    end
+
+    return exports.ox_target:addBoxZone(data)
+end
+
+local hasTextUi
+
+---@param point CPoint
+function Utils.nearbyMarker(point)
+    DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15,
+        ---@diagnostic disable-next-line: param-type-mismatch
+        point.marker[1], point.marker[2], point.marker[3], 222, false, false, 0, true, false, false, false)
+
+    if point.isClosest and point.currentDistance < 1.2 then
+        if not hasTextUi then
+            hasTextUi = point
+            lib.showTextUI(point.prompt.message, point.prompt.options)
+        end
+
+        if IsControlJustReleased(0, 38) then
+            CreateThread(function()
+                if point.inv == 'policeevidence' then
+                    client.openInventory('policeevidence')
+                elseif point.inv == 'crafting' then
+                    client.openInventory('crafting', { id = point.benchid, index = point.index })
+                else
+                    client.openInventory(point.inv or 'drop', { id = point.invId, type = point.type })
+                end
+            end)
+        end
+    elseif hasTextUi == point then
+        hasTextUi = nil
+        lib.hideTextUI()
+    end
+end
+
+return Utils

--- a/2.42.3/modules/weapon/client.lua
+++ b/2.42.3/modules/weapon/client.lua
@@ -1,0 +1,661 @@
+if not lib then return end
+
+local Weapon = {}
+local Items = require 'modules.items.client'
+local Utils = require 'modules.utils.client'
+
+-- generic group animation data
+local anims = {}
+anims[`GROUP_MELEE`] = { 'melee@holster', 'unholster', 200, 'melee@holster', 'holster', 600 }
+anims[`GROUP_PISTOL`] = { 'reaction@intimidation@cop@unarmed', 'intro', 400, 'reaction@intimidation@cop@unarmed', 'outro', 450 }
+anims[`GROUP_STUNGUN`] = anims[`GROUP_PISTOL`]
+
+local function vehicleIsCycle(vehicle)
+	local class = GetVehicleClass(vehicle)
+	return class == 8 or class == 13
+end
+
+function Weapon.Equip(item, data, noWeaponAnim)
+	local playerPed = cache.ped
+	local coords = GetEntityCoords(playerPed, true)
+    local sleep
+
+	if client.weaponanims then
+		if noWeaponAnim or (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			goto skipAnim
+		end
+
+		local anim = data.anim or anims[GetWeapontypeGroup(data.hash)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		sleep = anim and anim[3] or 1200
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)--added by Holger
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+	end
+
+	::skipAnim::
+
+	item.hash = data.hash
+	item.ammo = data.ammoname
+	item.melee = GetWeaponDamageType(data.hash) == 2 and 0
+	item.timer = 0
+	item.throwable = data.throwable
+	item.group = GetWeapontypeGroup(item.hash)
+
+	GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+
+	if item.metadata.tint then SetPedWeaponTintIndex(playerPed, data.hash, item.metadata.tint) end
+
+	if item.metadata.components then
+		for i = 1, #item.metadata.components do
+			local components = Items[item.metadata.components[i]].client.component
+			for v=1, #components do
+				local component = components[v]
+				if DoesWeaponTakeWeaponComponent(data.hash, component) then
+					if not HasPedGotWeaponComponent(playerPed, data.hash, component) then
+						GiveWeaponComponentToPed(playerPed, data.hash, component)
+					end
+				end
+			end
+		end
+	end
+
+	if item.metadata.specialAmmo then
+		local clipComponentKey = ('%s_CLIP'):format(data.model:gsub('WEAPON_', 'COMPONENT_'))
+		local specialClip = ('%s_%s'):format(clipComponentKey, item.metadata.specialAmmo:upper())
+
+		if DoesWeaponTakeWeaponComponent(data.hash, specialClip) then
+			GiveWeaponComponentToPed(playerPed, data.hash, specialClip)
+		end
+	end
+
+	local ammo = item.metadata.ammo or item.throwable and 1 or 0
+
+	SetCurrentPedWeapon(playerPed, data.hash, true)
+	SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+	SetWeaponsNoAutoswap(true)
+	SetPedAmmo(playerPed, data.hash, ammo)
+	SetTimeout(0, function() RefillAmmoInstantly(playerPed) end)
+
+	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
+		item.metadata.ammo = item.metadata.durability
+		SetPedInfiniteAmmo(playerPed, true, data.hash)
+	end
+
+	TriggerEvent('ox_inventory:currentWeapon', item)
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
+
+	return item, sleep
+end
+
+function Weapon.Disarm(currentWeapon, noAnim,waffenlos)		--waffenlos added by Holger
+	if currentWeapon?.timer then
+		currentWeapon.timer = nil
+
+        TriggerServerEvent('ox_inventory:updateWeapon')
+		--SetPedAmmo(cache.ped, currentWeapon.hash, 0)		--disabled by Holger
+
+		if client.weaponanims and not noAnim then
+			if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+				goto skipAnim
+			end
+
+			ClearPedSecondaryTask(cache.ped)
+
+			local item = Items[currentWeapon.name]
+			local coords = GetEntityCoords(cache.ped, true)
+			local anim = item.anim or anims[GetWeapontypeGroup(currentWeapon.hash)]
+
+			if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+				anim = nil
+			end
+
+			local sleep = anim and anim[6] or 1400
+
+			
+			if waffenlos then		--if added by Holger
+				GiveWeaponToPed(cache.ped, currentWeapon.hash, 0, false, true)
+			end
+
+			Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+		end
+
+		::skipAnim::
+
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
+		if (not EnableWeaponWheel and currentWeapon ~= nil) then
+			RemoveAllPedWeapons(cache.ped,true)
+		elseif waffenlos and currentWeapon ~= nil then
+	
+
+			GiveWeaponToPed(cache.ped, -1569615261, 0, false, true)
+		end
+
+		TriggerEvent('ox_inventory:currentWeapon')
+	end
+
+--[[ 	Utils.WeaponWheel()					--disabled by Holger
+	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
+	end ]]
+end
+
+--Holgers part starts
+
+
+Weapon.triggerAnimation = function(waffenhashalt,waffenhashneu,wert)
+	if wert then
+		local playerPed = cache.ped
+		local coords = GetEntityCoords(playerPed, true)
+		local sleep
+
+		if  (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			return
+		end
+
+		local anim = anims[GetWeapontypeGroup(waffenhashneu)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+
+		sleep = anim and anim[3] or 1100
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+
+		GiveWeaponToPed(playerPed, waffenhashneu, 250, false, true)
+		sleep = 0
+
+	else
+		if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+			return
+		end
+		local sleep
+
+
+		ClearPedSecondaryTask(cache.ped)
+
+		local coords = GetEntityCoords(cache.ped, true)
+		local anim = anims[GetWeapontypeGroup(waffenhashalt)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		local sleep = anim and anim[6] or 1000
+
+		GiveWeaponToPed(cache.ped, waffenhashalt, 0, false, true)
+		
+		Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+	end
+
+end
+
+--Holgers part ends
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+	RemoveAllPedWeapons(cache.ped, true)		--added by Holger
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+--added by Holger thanks to 5Labs for providing the list
+
+Weapon.WeaponByHash = {
+	[-1768145561] = {
+	["name"] = 'WEAPON_SPECIALCARBINE_MK2',
+	["label"] = 'Special Carbine MK2',
+	},
+	[487013001] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN',
+	["label"] = 'Pump Shotgun',
+	},
+	[-1075685676] = {
+	["name"] = 'WEAPON_PISTOL_MK2',
+	["label"] = 'Pistol MK2',
+	},
+	[-1238556825] = {
+	["name"] = 'WEAPON_RAYMINIGUN',
+	["label"] = 'Widowmaker',
+	},
+	[-1834847097] = {
+	["name"] = 'WEAPON_DAGGER',
+	["label"] = 'Dagger',
+	},
+	[-2067956739] = {
+	["name"] = 'WEAPON_CROWBAR',
+	["label"] = 'Crowbar',
+	},
+	[650961374] = {
+	["name"] = 'WEAPON_TEARGAS',
+	["label"] = 'Tear Gas',
+	},
+	[-618237638] = {
+	["name"] = 'WEAPON_EMPLAUNCHER',
+	["label"] = 'Compact EMP Launcher',
+	},
+	[-2084633992] = {
+	["name"] = 'WEAPON_CARBINERIFLE',
+	["label"] = 'Carbine Rifle',
+	},
+	[940833800] = {
+	["name"] = 'WEAPON_STONE_HATCHET',
+	["label"] = 'Stone Hatchet',
+	},
+	[-1716589765] = {
+	["name"] = 'WEAPON_PISTOL50',
+	["label"] = 'Pistol .50',
+	},
+	[-1716189206] = {
+	["name"] = 'WEAPON_KNIFE',
+	["label"] = 'Knife',
+	},
+	[1853742572] = {
+	["name"] = 'WEAPON_PRECISIONRIFLE',
+	["label"] = 'Precision Rifle',
+	},
+	[-1076751822] = {
+	["name"] = 'WEAPON_SNSPISTOL',
+	["label"] = 'SNS Pistol',
+	},
+	[1198879012] = {
+	["name"] = 'WEAPON_FLAREGUN',
+	["label"] = 'Flare Gun',
+	},
+	[-1355376991] = {
+	["name"] = 'WEAPON_RAYPISTOL',
+	["label"] = 'Up-n-Atomizer',
+	},
+	[-1813897027] = {
+	["name"] = 'WEAPON_GRENADE',
+	["label"] = 'Grenade',
+	},
+	[1737195953] = {
+	["name"] = 'WEAPON_NIGHTSTICK',
+	["label"] = 'Nightstick',
+	},
+	[1198256469] = {
+	["name"] = 'WEAPON_RAYCARBINE',
+	["label"] = 'Unholy Hellbringer',
+	},
+	[465894841] = {
+	["name"] = 'WEAPON_PISTOLXM3',
+	["label"] = 'WM 29 Pistol',
+	},
+	[1432025498] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN_MK2',
+	["label"] = 'Pump Shotgun MK2',
+	},
+	[100416529] = {
+	["name"] = 'WEAPON_SNIPERRIFLE',
+	["label"] = 'Sniper Rifle',
+	},
+	[1593441988] = {
+	["name"] = 'WEAPON_COMBATPISTOL',
+	["label"] = 'Glock',
+	},
+	[-581044007] = {
+	["name"] = 'WEAPON_MACHETE',
+	["label"] = 'Machete',
+	},
+	[-275439685] = {
+	["name"] = 'WEAPON_DBSHOTGUN',
+	["label"] = 'Double Barrel Shotgun',
+	},
+	[-1063057011] = {
+	["name"] = 'WEAPON_SPECIALCARBINE',
+	["label"] = 'Special Carbine',
+	},
+	[-1951375401] = {
+	["name"] = 'WEAPON_FLASHLIGHT',
+	["label"] = 'Flashlight',
+	},
+	[727643628] = {
+	["name"] = 'WEAPON_CERAMICPISTOL',
+	["label"] = 'Ceramic Pistol',
+	},
+	[584646201] = {
+	["name"] = 'WEAPON_APPISTOL',
+	["label"] = 'AP Pistol',
+	},
+	[-1045183535] = {
+	["name"] = 'WEAPON_REVOLVER',
+	["label"] = 'Revolver',
+	},
+	[-22923932] = {
+	["name"] = 'WEAPON_RAILGUNXM3',
+	["label"] = 'Railgun XM3',
+	},
+	[324215364] = {
+	["name"] = 'WEAPON_MICROSMG',
+	["label"] = 'Micro SMG',
+	},
+	[-1600701090] = {
+	["name"] = 'WEAPON_BZGAS',
+	["label"] = 'BZ Gas',
+	},
+	[-1168940174] = {
+	["name"] = 'WEAPON_HAZARDCAN',
+	["label"] = 'Hazard Can',
+	},
+	[-608341376] = {
+	["name"] = 'WEAPON_COMBATMG_MK2',
+	["label"] = 'Combat MG MK2',
+	},
+	[-538741184] = {
+	["name"] = 'WEAPON_SWITCHBLADE',
+	["label"] = 'Switchblade',
+	},
+	[984333226] = {
+	["name"] = 'WEAPON_HEAVYSHOTGUN',
+	["label"] = 'Heavy Shotgun',
+	},
+	[1785463520] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE_MK2',
+	["label"] = 'Marksman Rifle MK2',
+	},
+	[2024373456] = {
+	["name"] = 'WEAPON_SMG_MK2',
+	["label"] = 'SMG Mk2',
+	},
+	[1649403952] = {
+	["name"] = 'WEAPON_COMPACTRIFLE',
+	["label"] = 'Compact Rifle',
+	},
+	[615608432] = {
+	["name"] = 'WEAPON_MOLOTOV',
+	["label"] = 'Molotov',
+	},
+	[600439132] = {
+	["name"] = 'WEAPON_BALL',
+	["label"] = 'Ball',
+	},
+	[-952879014] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE',
+	["label"] = 'Marksman Rifle',
+	},
+	[-610080759] = {
+	["name"] = 'WEAPON_METALDETECTOR',
+	["label"] = 'Metal Detector',
+	},
+	[2017895192] = {
+	["name"] = 'WEAPON_SAWNOFFSHOTGUN',
+	["label"] = 'Sawn Off Shotgun',
+	},
+	[-1568386805] = {
+	["name"] = 'WEAPON_GRENADELAUNCHER',
+	["label"] = 'Grenade Launcher',
+	},
+	[-270015777] = {
+	["name"] = 'WEAPON_ASSAULTSMG',
+	["label"] = 'Assault SMG',
+	},
+	[-1466123874] = {
+	["name"] = 'WEAPON_MUSKET',
+	["label"] = 'Musket',
+	},
+	[-37975472] = {
+	["name"] = 'WEAPON_SMOKEGRENADE',
+	["label"] = 'Smoke Grenade',
+	},
+	[-1654528753] = {
+	["name"] = 'WEAPON_BULLPUPSHOTGUN',
+	["label"] = 'Bullpup Shotgun',
+	},
+	[1317494643] = {
+	["name"] = 'WEAPON_HAMMER',
+	["label"] = 'Hammer',
+	},
+	[137902532] = {
+	["name"] = 'WEAPON_VINTAGEPISTOL',
+	["label"] = 'Vintage Pistol',
+	},
+	[-853065399] = {
+	["name"] = 'WEAPON_BATTLEAXE',
+	["label"] = 'Battle Axe',
+	},
+	[-1660422300] = {
+	["name"] = 'WEAPON_MG',
+	["label"] = 'Machine Gun',
+	},
+	[1470379660] = {
+	["name"] = 'WEAPON_GADGETPISTOL',
+	["label"] = 'Perico Pistol',
+	},
+	[-1853920116] = {
+	["name"] = 'WEAPON_NAVYREVOLVER',
+	["label"] = 'Navy Revolver',
+	},
+	[94989220] = {
+	["name"] = 'WEAPON_COMBATSHOTGUN',
+	["label"] = 'Combat Shotgun',
+	},
+	[2144741730] = {
+	["name"] = 'WEAPON_COMBATMG',
+	["label"] = 'Combat MG',
+	},
+	[317205821] = {
+	["name"] = 'WEAPON_AUTOSHOTGUN',
+	["label"] = 'Sweeper Shotgun',
+	},
+	[883325847] = {
+	["name"] = 'WEAPON_PETROLCAN',
+	["label"] = 'Gas Can',
+	},
+	[-1357824103] = {
+	["name"] = 'WEAPON_ADVANCEDRIFLE',
+	["label"] = 'Advanced Rifle',
+	},
+	[736523883] = {
+	["name"] = 'WEAPON_SMG',
+	["label"] = 'SMG',
+	},
+	[205991906] = {
+	["name"] = 'WEAPON_HEAVYSNIPER',
+	["label"] = 'Heavy Sniper',
+	},
+	[-1312131151] = {
+	["name"] = 'WEAPON_RPG',
+	["label"] = 'RPG',
+	},
+	[-771403250] = {
+	["name"] = 'WEAPON_HEAVYPISTOL',
+	["label"] = 'Heavy Pistol',
+	},
+	[-879347409] = {
+	["name"] = 'WEAPON_REVOLVER_MK2',
+	["label"] = 'Revolver MK2',
+	},
+	[-494615257] = {
+	["name"] = 'WEAPON_ASSAULTSHOTGUN',
+	["label"] = 'Assault Shotgun',
+	},
+	[-947031628] = {
+	["name"] = 'WEAPON_HEAVYRIFLE',
+	["label"] = 'Heavy Rifle',
+	},
+	[-1420407917] = {
+	["name"] = 'WEAPON_PROXMINE',
+	["label"] = 'Proximity Mine',
+	},
+	[-619010992] = {
+	["name"] = 'WEAPON_MACHINEPISTOL',
+	["label"] = 'Machine Pistol',
+	},
+	[-1746263880] = {
+	["name"] = 'WEAPON_DOUBLEACTION',
+	["label"] = 'Double Action Revolver',
+	},
+	[125959754] = {
+	["name"] = 'WEAPON_COMPACTLAUNCHER',
+	["label"] = 'Compact Grenade Launcher',
+	},
+	[2132975508] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE',
+	["label"] = 'Bullpup Rifle',
+	},
+	[-86904375] = {
+	["name"] = 'WEAPON_CARBINERIFLE_MK2',
+	["label"] = 'Carbine Rifle MK2',
+	},
+	[453432689] = {
+	["name"] = 'WEAPON_PISTOL',
+	["label"] = 'Pistol',
+	},
+	[-1074790547] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE',
+	["label"] = 'Assault Rifle',
+	},
+	[1627465347] = {
+	["name"] = 'WEAPON_GUSENBERG',
+	["label"] = 'Gusenberg',
+	},
+	[911657153] = {
+	["name"] = 'WEAPON_STUNGUN',
+	["label"] = 'Tazer',
+	},
+	[-1121678507] = {
+	["name"] = 'WEAPON_MINISMG',
+	["label"] = 'Mini SMG',
+	},
+	[171789620] = {
+	["name"] = 'WEAPON_COMBATPDW',
+	["label"] = 'Combat PDW',
+	},
+	[1141786504] = {
+	["name"] = 'WEAPON_GOLFCLUB',
+	["label"] = 'Golf Club',
+	},
+	[1834241177] = {
+	["name"] = 'WEAPON_RAILGUN',
+	["label"] = 'Railgun',
+	},
+	[1119849093] = {
+	["name"] = 'WEAPON_MINIGUN',
+	["label"] = 'Minigun',
+	},
+	[961495388] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE_MK2',
+	["label"] = 'Assault Rifle MK2',
+	},
+	[406929569] = {
+	["name"] = 'WEAPON_FERTILIZERCAN',
+	["label"] = 'Fertilizer Can',
+	},
+	[1233104067] = {
+	["name"] = 'WEAPON_FLARE',
+	["label"] = 'Flare',
+	},
+	[419712736] = {
+	["name"] = 'WEAPON_WRENCH',
+	["label"] = 'Wrench',
+	},
+	[-2009644972] = {
+	["name"] = 'WEAPON_SNSPISTOL_MK2',
+	["label"] = 'SNS Pistol MK2',
+	},
+	[-102973651] = {
+	["name"] = 'WEAPON_HATCHET',
+	["label"] = 'Hatchet',
+	},
+	[-2066285827] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE_MK2',
+	["label"] = 'Bullpup Rifle MK2',
+	},
+	[-1169823560] = {
+	["name"] = 'WEAPON_PIPEBOMB',
+	["label"] = 'Pipe Bomb',
+	},
+	[1703483498] = {
+	["name"] = 'WEAPON_CANDYCANE',
+	["label"] = 'Candy Cane',
+	},
+	[-598887786] = {
+	["name"] = 'WEAPON_MARKSMANPISTOL',
+	["label"] = 'Marksman Pistol',
+	},
+	[350597077] = {
+	["name"] = 'WEAPON_TECPISTOL',
+	["label"] = 'Tactical SMG',
+	},
+	[-1786099057] = {
+	["name"] = 'WEAPON_BAT',
+	["label"] = 'Bat',
+	},
+	[2138347493] = {
+	["name"] = 'WEAPON_FIREWORK',
+	["label"] = 'Firework Launcher',
+	},
+	[-1658906650] = {
+	["name"] = 'WEAPON_MILITARYRIFLE',
+	["label"] = 'Military Rifle',
+	},
+	[-656458692] = {
+	["name"] = 'WEAPON_KNUCKLE',
+	["label"] = 'Knuckle Dusters',
+	},
+	[126349499] = {
+	["name"] = 'WEAPON_SNOWBALL',
+	["label"] = 'Snow Ball',
+	},
+	[177293209] = {
+	["name"] = 'WEAPON_HEAVYSNIPER_MK2',
+	["label"] = 'Heavy Sniper MK2',
+	},
+	[-774507221] = {
+	["name"] = 'WEAPON_TACTICALRIFLE',
+	["label"] = 'Tactical Rifle',
+	},
+	[101631238] = {
+	["name"] = 'WEAPON_FIREEXTINGUISHER',
+	["label"] = 'Fire Extinguisher',
+	},
+	[-102323637] = {
+	["name"] = 'WEAPON_BOTTLE',
+	["label"] = 'Bottle',
+	},
+	[741814745] = {
+	["name"] = 'WEAPON_STICKYBOMB',
+	["label"] = 'Sticky Bomb',
+	},
+	[1672152130] = {
+	["name"] = 'WEAPON_HOMINGLAUNCHER',
+	["label"] = 'Homing Launcher',
+	},
+	[-1810795771] = {
+	["name"] = 'WEAPON_POOLCUE',
+	["label"] = 'Pool Cue',
+	},
+}
+
+
+return Weapon

--- a/2.43.3/client.lua
+++ b/2.43.3/client.lua
@@ -1,0 +1,2080 @@
+if not lib then return end
+
+require 'modules.bridge.client'
+require 'modules.interface.client'
+
+local Utils = require 'modules.utils.client'
+local Weapon = require 'modules.weapon.client'
+local currentWeapon
+
+
+--Holgers Anpassungen
+
+HotbarundWeaponWheel = false
+EnableWeaponWheel = true
+Waffencache = {}
+
+--Holgers Anpassungen bis hier
+
+
+exports('getCurrentWeapon', function()
+	return currentWeapon
+end)
+
+RegisterNetEvent('ox_inventory:disarm', function(noAnim)
+	currentWeapon = Weapon.Disarm(currentWeapon, noAnim)
+end)
+
+RegisterNetEvent('ox_inventory:clearWeapons', function()
+	Weapon.ClearAll(currentWeapon)
+end)
+
+local StashTarget
+
+exports('setStashTarget', function(id, owner)
+	StashTarget = id and {id=id, owner=owner}
+end)
+
+---@type boolean | number
+local invBusy = true
+
+---@type boolean?
+local invOpen = false
+local plyState = LocalPlayer.state
+local IsPedCuffed = IsPedCuffed
+local playerPed = cache.ped
+
+lib.onCache('ped', function(ped)
+	playerPed = ped
+	Utils.WeaponWheel()
+end)
+
+plyState:set('invBusy', true, true)
+plyState:set('invHotkeys', false, false)
+plyState:set('canUseWeapons', false, false)
+
+local function canOpenInventory()
+    if not PlayerData.loaded then
+        return shared.info('cannot open inventory', '(player inventory has not loaded)')
+    end
+
+    if IsPauseMenuActive() then return end
+
+    if invBusy or invOpen == nil or (currentWeapon?.timer or 0) > 0 then
+        return shared.info('cannot open inventory', '(is busy)')
+    end
+
+    if PlayerData.dead or IsPedFatallyInjured(playerPed) then
+        return shared.info('cannot open inventory', '(fatal injury)')
+    end
+
+    if PlayerData.cuffed or IsPedCuffed(playerPed) then
+        return shared.info('cannot open inventory', '(cuffed)')
+    end
+
+    return true
+end
+
+---@param ped number
+---@return boolean
+local function canOpenTarget(ped)
+	return IsPedFatallyInjured(ped)
+	or IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3)
+	or IsPedCuffed(ped)
+	or IsEntityPlayingAnim(ped, 'mp_arresting', 'idle', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_enter', 3)
+	or IsEntityPlayingAnim(ped, 'random@mugging3', 'handsup_standing_base', 3)
+end
+
+local defaultInventory = {
+	type = 'newdrop',
+	slots = shared.playerslots,
+	weight = 0,
+	maxWeight = shared.playerweight,
+	items = {}
+}
+
+local currentInventory = defaultInventory
+
+local function closeTrunk()
+	if currentInventory?.type == 'trunk' then
+		local coords = GetEntityCoords(playerPed, true)
+		---@todo animation for vans?
+		Utils.PlayAnimAdvanced(0, 'anim@heists@fleeca_bank@scope_out@return_case', 'trevor_action', coords.x, coords.y, coords.z, 0.0, 0.0, GetEntityHeading(playerPed), 2.0, 2.0, 1000, 49, 0.25)
+
+		CreateThread(function()
+			local entity = currentInventory.entity
+			local door = currentInventory.door
+			Wait(900)
+
+			if type(door) == 'table' then
+				for i = 1, #door do
+					SetVehicleDoorShut(entity, door[i], false)
+				end
+			else
+				SetVehicleDoorShut(entity, door, false)
+			end
+		end)
+	end
+end
+
+local CraftingBenches = require 'modules.crafting.client'
+local Vehicles = lib.load('data.vehicles')
+local Inventory = require 'modules.inventory.client'
+
+---@param inv string?
+---@param data any?
+---@return boolean?
+function client.openInventory(inv, data)
+	if invOpen then
+		if not inv and currentInventory.type == 'newdrop' then
+			return client.closeInventory()
+		end
+
+		if IsNuiFocused() then
+			if inv == 'container' and currentInventory.id == PlayerData.inventory[data].metadata.container then
+				return client.closeInventory()
+			end
+
+			if currentInventory.type == 'drop' and (not data or currentInventory.id == (type(data) == 'table' and data.id or data)) then
+				return client.closeInventory()
+			end
+
+			if inv ~= 'drop' and inv ~= 'container' then
+				if (data?.id or data) == currentInventory?.id then
+					-- Triggering exports.ox_inventory:openInventory('stash', 'mystash') twice in rapid succession is weird behaviour
+					return warn(("script tried to open inventory, but it is already open\n%s"):format(Citizen.InvokeNative(`FORMAT_STACK_TRACE` & 0xFFFFFFFF, nil, 0, Citizen.ResultAsString())))
+				else
+					return client.closeInventory()
+				end
+			end
+		end
+	elseif IsNuiFocused() then
+		-- If triggering from another nui, may need to wait for focus to end.
+		Wait(100)
+
+        -- People still complain about this being an "error" and ask "how fix" despite being a warning
+        -- for people with above room-temperature iqs to look into resource conflicts on their own.
+		-- if IsNuiFocused() then
+		-- 	warn('other scripts have nui focus and may cause issues (e.g. disable focus, prevent input, overlap inventory window)')
+		-- end
+	end
+
+	if inv == 'dumpster' and cache.vehicle then
+		return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+	end
+
+	if not canOpenInventory() then
+        return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+    end
+
+    local left, right, accessError
+
+    if inv == 'player' and data ~= cache.serverId then
+        local targetId, targetPed
+
+        if not data then
+            targetId, targetPed = Utils.GetClosestPlayer()
+            data = targetId and GetPlayerServerId(targetId)
+        else
+            local serverId = type(data) == 'table' and data.id or data
+
+            if serverId == cache.serverId then return end
+
+            targetId = serverId and GetPlayerFromServerId(serverId)
+            targetPed = targetId and GetPlayerPed(targetId)
+        end
+
+        local targetCoords = targetPed and GetEntityCoords(targetPed)
+
+        if not targetCoords or #(targetCoords - GetEntityCoords(playerPed)) > 1.8 or not (client.hasGroup(shared.police) or canOpenTarget(targetPed)) then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+    end
+
+    if inv == 'shop' and invOpen == false then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
+    elseif inv == 'crafting' then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+
+        if left then
+            right = CraftingBenches[data.id]
+
+            if not right?.items then return end
+
+            local coords, distance
+
+            if not right.zones and not right.points then
+                coords = GetEntityCoords(cache.ped)
+                distance = 2
+            else
+                coords = shared.target and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+                distance = coords and shared.target and right.zones[data.index].distance or 2
+            end
+
+            right = {
+                type = 'crafting',
+                id = data.id,
+                label = right.label or locale('crafting_bench'),
+                index = data.index,
+                slots = right.slots,
+                items = right.items,
+                coords = coords,
+                distance = distance
+            }
+        end
+    elseif invOpen ~= nil then
+        if inv == 'policeevidence' then
+            if not data then
+                local input = lib.inputDialog(locale('police_evidence'), {
+                    { label = locale('locker_number'), type = 'number', required = true, icon = 'calculator' }
+                }) --[[@as number[]? ]]
+
+                if not input then return end
+
+                data = input[1]
+            end
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+    end
+
+    if accessError then
+        return lib.notify({ id = accessError, type = 'error', description = locale(accessError) })
+    end
+
+    -- Stash does not exist
+    if not left then
+        if left == false then return false end
+
+        if invOpen == false then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+
+        if invOpen then return client.closeInventory() end
+    end
+
+
+    if not cache.vehicle then
+        if inv == 'player' then
+            Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+        elseif inv ~= 'trunk' then
+            Utils.PlayAnim(0, 'pickup_object', 'putdown_low', 5.0, 1.5, 1000, 48, 0.0, 0, 0, 0)
+        end
+    end
+
+    plyState.invOpen = true
+
+    SetInterval(client.interval, 100)
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+    closeTrunk()
+
+    if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+    currentInventory = right or defaultInventory
+    left.items = PlayerData.inventory
+    left.groups = PlayerData.groups
+
+    SendNUIMessage({
+        action = 'setupInventory',
+        data = {
+            leftInventory = left,
+            rightInventory = currentInventory
+        }
+    })
+
+    if not currentInventory.coords and not inv == 'container' then
+        currentInventory.coords = GetEntityCoords(playerPed)
+    end
+
+    if inv == 'trunk' then
+        SetTimeout(200, function()
+            ---@todo animation for vans?
+            Utils.PlayAnim(0, 'anim@heists@prison_heiststation@cop_reactions', 'cop_b_idle', 3.0, 3.0, -1, 49, 0.0, 0, 0, 0)
+
+            local entity = data.entity or NetworkGetEntityFromNetworkId(data.netid)
+            currentInventory.entity = entity
+            currentInventory.door = data.door
+
+            if not currentInventory.door then
+                local vehicleHash = GetEntityModel(entity)
+                local vehicleClass = GetVehicleClass(entity)
+                currentInventory.door = vehicleClass == 12 and { 2, 3 } or Vehicles.Storage[vehicleHash] and 4 or 5
+            end
+
+            while currentInventory?.entity == entity and invOpen and DoesEntityExist(entity) and Inventory.CanAccessTrunk(entity) do
+                Wait(100)
+            end
+
+            if invOpen then client.closeInventory() end
+        end)
+    end
+
+    return true
+end
+
+RegisterNetEvent('ox_inventory:openInventory', client.openInventory)
+exports('openInventory', client.openInventory)
+
+RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+local Animations = lib.load('data.animations')
+local Items = require 'modules.items.client'
+local usingItem = false
+
+---@param data { name: string, label: string, count: number, slot: number, metadata: table<string, any>, weight: number }
+lib.callback.register('ox_inventory:usingItem', function(data, noAnim)
+	local item = Items[data.name]
+
+	if item and usingItem then
+		if not item.client then return true end
+		---@cast item +OxClientProps
+		item = item.client
+
+		if type(item.anim) == 'string' then
+			item.anim = Animations.anim[item.anim]
+		end
+
+		if item.prop then
+			if item.prop[1] then
+				for i = 1, #item.prop do
+					if type(item.prop) == 'string' then
+						item.prop = Animations.prop[item.prop[i]]
+					end
+				end
+			elseif type(item.prop) == 'string' then
+				item.prop = Animations.prop[item.prop]
+			end
+		end
+
+		if not item.disable then
+			item.disable = { combat = true }
+		elseif item.disable.combat == nil then
+			-- Backwards compatibility; you probably don't want people shooting while eating and bandaging anyway
+			item.disable.combat = true
+		end
+
+		local success = (not item.usetime or noAnim or lib.progressBar({
+			duration = item.usetime,
+			label = item.label or locale('using', data.metadata.label or data.label),
+			useWhileDead = item.useWhileDead,
+			canCancel = item.cancel,
+			disable = item.disable,
+			anim = item.anim or item.scenario,
+			prop = item.prop --[[@as ProgressProps]]
+		})) and not PlayerData.dead
+
+		if success then
+			if item.notification then
+				lib.notify({ description = item.notification })
+			end
+
+			if item.status then
+				if client.setPlayerStatus then
+					client.setPlayerStatus(item.status)
+				end
+			end
+
+			return true
+		end
+	end
+end)
+
+local function canUseItem(isAmmo)
+	local ped = cache.ped
+
+	return not usingItem
+    and (not isAmmo or currentWeapon)
+	and PlayerData.loaded
+	and not PlayerData.dead
+	and not invBusy
+	and not lib.progressActive()
+	and not IsPedRagdoll(ped)
+	and not IsPedFalling(ped)
+    and not IsPedShooting(playerPed)
+end
+
+---@param data table
+---@param cb fun(response: SlotWithItem | false)?
+---@param noAnim? boolean
+local function useItem(data, cb, noAnim)
+	local slotData, result = PlayerData.inventory[data.slot]
+
+	if not slotData or not canUseItem(data.ammo and true) then
+        if currentWeapon then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        return
+    end
+
+	if currentWeapon and currentWeapon.timer ~= 0 then
+        if not currentWeapon.timer or currentWeapon.timer - GetGameTimer() > 100 then return end
+
+        DisablePlayerFiring(cache.playerId, true)
+    end
+
+    if invOpen and data.close then client.closeInventory() end
+
+    usingItem = true
+    ---@type boolean?
+    result = lib.callback.await('ox_inventory:useItem', 200, data.name, data.slot, slotData.metadata, noAnim)
+
+	if result and cb then
+		local success, response = pcall(cb, result and slotData)
+
+		if not success and response then
+			warn(('^1An error occurred while calling item "%s" callback!\n^1SCRIPT ERROR: %s^0'):format(slotData.name, response))
+		end
+	end
+
+    if result then
+        TriggerEvent('ox_inventory:usedItem', slotData.name, slotData.slot, next(slotData.metadata) and slotData.metadata)
+    end
+
+	Wait(500)
+    usingItem = false
+end
+
+AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+end)
+
+AddEventHandler('ox_inventory:item', useItem)
+exports('useItem', useItem)
+
+---@param slot number
+---@return boolean?
+local function useSlot(slot, noAnim, dings) --dings added by Holger
+	local item = PlayerData.inventory[slot]
+	if not item then return end
+
+	local data = Items[item.name]
+	if not data then return end
+
+	if canUseItem(data.ammo and true) then
+		if data.component and not currentWeapon then
+			return lib.notify({ id = 'weapon_hand_required', type = 'error', description = locale('weapon_hand_required') })
+		end
+
+		local durability = item.metadata.durability --[[@as number?]]
+		local consume = data.consume --[[@as number?]]
+		local label = item.metadata.label or item.label --[[@as string]]
+
+		-- Naive durability check to get an early exit
+		-- People often don't call the 'useItem' export and then complain about "broken" items being usable
+		-- This won't work with degradation since we need access to os.time on the server
+		if durability and durability <= 100 and consume then
+			if durability <= 0 then
+				return lib.notify({ type = 'error', description = locale('no_durability', label) })
+			elseif consume ~= 0 and consume < 1 and durability < consume * 100 then
+				return lib.notify({ type = 'error', description = locale('not_enough_durability', label) })
+			end
+		end
+
+		data.slot = slot
+
+		if item.metadata.container then
+			return client.openInventory('container', item.slot)
+		elseif data.client then
+			if invOpen and data.close then client.closeInventory() end
+
+			if data.export then
+				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
+				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			end
+		end
+
+		if data.effect then
+			data:effect({name = item.name, slot = item.slot, metadata = item.metadata})
+		elseif data.weapon then
+			if not plyState.canUseWeapons then return end
+			if EnableWeaponWheel then -- if by Holger
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+
+					if dings then -- if by Holger
+						
+						currentWeapon =  Weapon.Disarm(currentWeapon,false,true)
+					else						
+						currentWeapon =  Weapon.Disarm(currentWeapon)
+					end
+
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			else
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+						
+					currentWeapon =  Weapon.Disarm(currentWeapon)
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			end
+		elseif currentWeapon then
+			if data.ammo then
+				if Utils.Waffensyncaus or currentWeapon.metadata.durability <= 0 then return end ----Holger replaced : EnableWeaponWheel to Utils.Waffensyncaus
+
+				local clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+				local currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+				local _, maxAmmo = GetMaxAmmo(playerPed, currentWeapon.hash)
+
+				if maxAmmo < clipSize then clipSize = maxAmmo end
+
+				if currentAmmo == clipSize then return end
+
+				useItem(data, function(resp)
+					if not resp or resp.name ~= currentWeapon?.ammo then return end
+
+					if currentWeapon.metadata.specialAmmo ~= resp.metadata.type and type(currentWeapon.metadata.specialAmmo) == 'string' then
+						local clipComponentKey = ('%s_CLIP'):format(Items[currentWeapon.name].model:gsub('WEAPON_', 'COMPONENT_'))
+						local specialClip = ('%s_%s'):format(clipComponentKey, (resp.metadata.type or currentWeapon.metadata.specialAmmo):upper())
+
+						if type(resp.metadata.type) == 'string' then
+							if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+								if not DoesWeaponTakeWeaponComponent(currentWeapon.hash, specialClip) then
+									warn('cannot use clip with this weapon')
+									return
+								end
+
+								local defaultClip = ('%s_01'):format(clipComponentKey)
+
+								if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, defaultClip) then
+									warn('cannot use clip with currently equipped clip')
+									return
+								end
+
+								if currentAmmo > 0 then
+									warn('cannot mix special ammo with base ammo')
+									return
+								end
+
+								currentWeapon.metadata.specialAmmo = resp.metadata.type
+
+								GiveWeaponComponentToPed(playerPed, currentWeapon.hash, specialClip)
+							end
+						elseif HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+							if currentAmmo > 0 then
+								warn('cannot mix special ammo with base ammo')
+								return
+							end
+
+							currentWeapon.metadata.specialAmmo = nil
+
+							RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, specialClip)
+						end
+					end
+
+					if maxAmmo > clipSize then
+						clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+					end
+
+					currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+					local missingAmmo = clipSize - currentAmmo
+					local addAmmo = resp.count > missingAmmo and missingAmmo or resp.count
+					local newAmmo = currentAmmo + addAmmo
+
+					if newAmmo == currentAmmo then return end
+
+                    AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
+
+					if cache.vehicle then
+						if cache.seat > -1 or IsVehicleStopped(cache.vehicle) then
+							TaskReloadWeapon(playerPed, true)
+                        else
+                            -- This is a hacky solution for forcing ammo to properly load into the
+                            -- weapon clip while driving; without it, ammo will be added but won't
+                            -- load until the player stops doing anything. i.e. if you keep shooting,
+                            -- the weapon will not reload until the clip empties.
+                            -- And yes - for some reason RefillAmmoInstantly needs to run in a loop.
+                            lib.waitFor(function()
+                                RefillAmmoInstantly(playerPed)
+
+                                local _, ammo = GetAmmoInClip(playerPed, currentWeapon.hash)
+                                return ammo == newAmmo or nil
+                            end)
+                        end
+					else
+						Wait(100)
+						MakePedReload(playerPed)
+
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
+					end
+
+					lib.callback.await('ox_inventory:updateWeapon', false, 'load', newAmmo, false, currentWeapon.metadata.specialAmmo)
+				end)
+			elseif data.component then
+				local components = data.client.component
+
+                if not components then return end
+
+				local componentType = data.type
+				local weaponComponents = PlayerData.inventory[currentWeapon.slot].metadata.components
+
+				-- Checks if the weapon already has the same component type attached
+				for componentIndex = 1, #weaponComponents do
+					if componentType == Items[weaponComponents[componentIndex]].type then
+						return lib.notify({ id = 'component_slot_occupied', type = 'error', description = locale('component_slot_occupied', componentType) })
+					end
+				end
+
+				for i = 1, #components do
+					local component = components[i]
+
+					if DoesWeaponTakeWeaponComponent(currentWeapon.hash, component) then
+						if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+							lib.notify({ id = 'component_has', type = 'error', description = locale('component_has', label) })
+						else
+							useItem(data, function(data)
+								if data then
+									local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', tostring(data.slot), currentWeapon.slot)
+
+									if success then
+										GiveWeaponComponentToPed(playerPed, currentWeapon.hash, component)
+										TriggerEvent('ox_inventory:updateWeaponComponent', 'added', component, data.name)
+									end
+								end
+							end)
+						end
+						return
+					end
+				end
+				lib.notify({ id = 'component_invalid', type = 'error', description = locale('component_invalid', label) })
+			elseif data.allowArmed then
+				useItem(data)
+            else
+                return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+			end
+		elseif not data.ammo and not data.component then
+			useItem(data)
+		end
+    end
+end
+exports('useSlot', useSlot)
+
+---@param id number
+---@param slot number
+local function useButton(id, slot)
+	if PlayerData.loaded and not invBusy and not lib.progressActive() then
+		local item = PlayerData.inventory[slot]
+		if not item then return end
+
+		local data = Items[item.name]
+		local buttons = data?.buttons
+
+		if buttons and buttons[id]?.action then
+			buttons[id].action(slot)
+		end
+	end
+end
+
+local function openNearbyInventory() client.openInventory('player') end
+
+exports('openNearbyInventory', openNearbyInventory)
+
+local currentInstance
+local playerCoords
+local Shops = require 'modules.shops.client'
+
+---@todo remove or replace when the bridge module gets restructured
+function OnPlayerData(key, val)
+	if key ~= 'groups' and key ~= 'ped' and key ~= 'dead' then return end
+
+	if key == 'groups' then
+		Inventory.Stashes()
+		Inventory.Evidence()
+		Shops.refreshShops()
+	elseif key == 'dead' and val then
+		currentWeapon = Weapon.Disarm(currentWeapon)
+		client.closeInventory()
+	end
+
+	Utils.WeaponWheel()
+end
+
+-- People consistently ignore errors when one of the "modules" failed to load
+if not Utils or not Weapon or not Items or not Inventory then return end
+
+local invHotkeys = false
+
+---@type function?
+local function registerCommands()
+	RegisterCommand('steal', openNearbyInventory, false)
+
+	local function openGlovebox(vehicle)
+		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end
+
+		local vehicleHash = GetEntityModel(vehicle)
+		local vehicleClass = GetVehicleClass(vehicle)
+		local checkVehicle = Vehicles.Storage[vehicleHash]
+
+		-- No storage or no glovebox
+		if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
+
+		local isOpen = client.openInventory('glovebox', { netid = NetworkGetNetworkIdFromEntity(vehicle) })
+
+		if isOpen then
+			currentInventory.entity = vehicle
+		end
+	end
+
+	local primary = lib.addKeybind({
+		name = 'inv',
+		description = locale('open_player_inventory'),
+		defaultKey = client.keys[1],
+		onPressed = function()
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local closest = lib.points.getClosestPoint()
+
+			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
+				if closest.inv == 'crafting' then
+					return client.openInventory('crafting', { id = closest.id, index = closest.index })
+				elseif closest.inv ~= 'license' and closest.inv ~= 'policeevidence' then
+					return client.openInventory(closest.inv or 'drop', { id = closest.invId, type = closest.type })
+				end
+			end
+
+			return client.openInventory()
+		end
+	})
+
+	lib.addKeybind({
+		name = 'inv2',
+		description = locale('open_secondary_inventory'),
+		defaultKey = client.keys[2],
+		onPressed = function(self)
+            if primary:getCurrentKey() == self:getCurrentKey() then
+                return warn(("secondary inventory keybind '%s' disabled (keybind cannot match primary inventory keybind)"):format(self:getCurrentKey()))
+            end
+
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if invBusy or not canOpenInventory() then
+				return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+			end
+
+			if StashTarget then
+				return client.openInventory('stash', StashTarget)
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local entity, entityType = Utils.Raycast(2|16)
+
+			if not entity then return end
+
+			if not shared.target and entityType == 3 then
+				local model = GetEntityModel(entity)
+
+				if Inventory.Dumpsters[model] then
+					return Inventory.OpenDumpster(entity)
+				end
+			end
+
+			if entityType ~= 2 then return end
+
+			Inventory.OpenTrunk(entity)
+		end
+	})
+
+	lib.addKeybind({
+		name = 'reloadweapon',
+		description = locale('reload_weapon'),
+		defaultKey = 'r',
+		onPressed = function(self)
+			if not currentWeapon or Utils.Waffensyncaus or not canUseItem(true) then return end ---Holger changed   EnableWeaponWheel  to Utils.Waffensyncaus
+
+			if currentWeapon.ammo then
+				if currentWeapon.metadata.durability > 0 then
+					local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+					if slotId then
+						useSlot(slotId)
+					end
+				else
+					lib.notify({ id = 'no_durability', type = 'error', description = locale('no_durability', currentWeapon.label) })
+				end
+			end
+		end
+	})
+
+	lib.addKeybind({
+		name = 'hotbar',
+		description = locale('disable_hotbar'),
+		defaultKey = client.keys[3],
+		onPressed = function()
+			if (EnableWeaponWheel and not HotbarundWeaponWheel) or IsNuiFocused() or lib.progressActive() then return end --Holger added: and not HotbarundWeaponWheel
+			SendNUIMessage({ action = 'toggleHotbar' })
+		end
+	})
+
+	for i = 1, 5 do
+		lib.addKeybind({
+			name = ('hotkey%s'):format(i),
+			description = locale('use_hotbar', i),
+			defaultKey = tostring(i),
+			onPressed = function()
+				if invOpen or (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() then return end --Holger added: and not HotbarundWeaponWheel
+				useSlot(i)
+			end
+		})
+	end
+
+	registerCommands = nil
+end
+
+function client.closeInventory(server)
+	-- because somehow people are triggering this when the inventory isn't loaded
+	-- and they're incapable of debugging, and I can't repro on a fresh install
+	if not client.interval then return end
+
+	if invOpen then
+		invOpen = nil
+		SetNuiFocus(false, false)
+		SetNuiFocusKeepInput(false)
+		TriggerScreenblurFadeOut(0)
+		closeTrunk()
+		SendNUIMessage({ action = 'closeInventory' })
+		SetInterval(client.interval, 200)
+		Wait(200)
+
+		if invOpen ~= nil then return end
+
+		if not server and currentInventory then
+			TriggerServerEvent('ox_inventory:closeInventory')
+		end
+
+		currentInventory = nil
+		plyState.invOpen = false
+		defaultInventory.coords = nil
+	end
+end
+
+RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
+exports('closeInventory', client.closeInventory)
+
+---@param data updateSlot[]
+---@param weight number
+local function updateInventory(data, weight)
+	local changes = {}
+    ---@type table<string, number>
+	local itemCount = {}
+
+	for i = 1, #data do
+		local v = data[i]
+
+		if not v.inventory or v.inventory == cache.serverId then
+			v.inventory = 'player'
+			local item = v.item
+
+			if currentWeapon?.slot == item?.slot then
+                if item.metadata then
+				    currentWeapon.metadata = item.metadata
+				    TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
+                else
+                    currentWeapon = Weapon.Disarm(currentWeapon, true)
+                end
+			end
+
+			local curItem = PlayerData.inventory[item.slot]
+
+			if curItem and curItem.name then  -- if changed by Holger
+				if itemCount[curItem.name] == nil then
+					itemCount[curItem.name] = {}
+				end
+				itemCount[curItem.name].count = (itemCount[curItem.name].count or 0) - curItem.count
+				itemCount[curItem.name].slot = item.slot
+			end
+
+			if item.count then	-- if changed by Holger
+				if itemCount[item.name] == nil then
+					itemCount[item.name] = {}
+				end
+				itemCount[item.name].count = (itemCount[item.name].count or 0) + item.count
+				itemCount[item.name].slot = item.slot
+			end
+
+			changes[item.slot] = item.count and item or false
+			if not item.count then item.name = nil end
+			PlayerData.inventory[item.slot] = item.name and item or nil
+		end
+	end
+
+	SendNUIMessage({ action = 'refreshSlots', data = { items = data, itemCount = itemCount} })
+
+    if weight ~= PlayerData.weight then client.setPlayerData('weight', weight) end
+
+	for itemName, dings in pairs(itemCount) do --changed count to dings  	Holger
+		local item = Items(itemName)
+		
+
+        if item then
+            item.count += dings.count --added dings. 	Holger
+
+			------------Holgers Anpassungen
+			if string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN"  and item.count  >0 and not HasPedGotWeapon(cache.ped,item.name,false) then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash] = {}
+				Waffencache[hash].name = item.name
+				Waffencache[hash].slot = dings.slot
+				Waffencache[hash].hash = hash
+				
+				RemoveWeaponFromPed(cache.ped,item.name)
+				GiveWeaponToPed(cache.ped,item.name,1,false,false) 
+			elseif string.sub(item.name,1,7) =="WEAPON_" and item.count  == 0 then
+				local loeschdas
+				for k,v in pairs(Waffencache) do
+					if v.name ==item.name then
+						loeschdas = k
+					end
+				end
+				Waffencache[loeschdas] = nil
+				if currentWeapon and currentWeapon.name == item.name then
+					currentWeapon = Weapon.Disarm(currentWeapon, false,"lurch")
+				else
+					RemoveWeaponFromPed(cache.ped,item.name)
+				end 
+			end
+
+			-----Holgers Anpassungen ende
+
+            TriggerEvent('ox_inventory:itemCount', item.name, item.count)
+
+            if dings.count < 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:removeInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.remove then
+                    item.client.remove(item.count)
+                end
+            elseif dings.count > 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:addInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.add then
+                    item.client.add(item.count)
+                end
+            end
+        end
+	end
+
+	client.setPlayerData('inventory', PlayerData.inventory)
+	TriggerEvent('ox_inventory:updateInventory', changes)
+end
+
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
+	if source ~= '' and next(items) then updateInventory(items, weights) end
+end)
+
+RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
+	if source == '' then return end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	lib.notify({ description = locale('items_returned') })
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for _, slotData in pairs(data[1]) do
+		num += 1
+		items[num] = { item = slotData, inventory = cache.serverId }
+	end
+
+	updateInventory(items, data[3])
+end)
+
+RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
+	if source == '' then return end
+	if message then lib.notify({ description = locale('items_confiscated') }) end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for slot in pairs(PlayerData.inventory) do
+		num += 1
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
+	end
+
+	updateInventory(items, 0)
+end)
+
+
+---@param point CPoint
+local function nearbyDrop(point)
+	if not point.instance or point.instance == currentInstance then
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 150, 30, 30, 222, false, false, 0, true, false, false, false)
+	end
+end
+
+---@param point CPoint
+local function onEnterDrop(point)
+	if not point.instance or point.instance == currentInstance and not point.entity then
+		local model = point.model or client.dropmodel
+
+        -- Prevent breaking inventory on invalid point.model instead use default client.dropmodel
+        if not IsModelValid(model) and not IsModelInCdimage(model) then
+            model = client.dropmodel
+        end
+		lib.requestModel(model)
+
+		local entity = CreateObject(model, point.coords.x, point.coords.y, point.coords.z, false, true, true)
+
+		SetModelAsNoLongerNeeded(model)
+		PlaceObjectOnGroundProperly(entity)
+		FreezeEntityPosition(entity, true)
+		SetEntityCollision(entity, false, true)
+
+		point.entity = entity
+	end
+end
+
+local function onExitDrop(point)
+	local entity = point.entity
+
+	if entity then
+		Utils.DeleteEntity(entity)
+		point.entity = nil
+	end
+end
+
+local function createDrop(dropId, data)
+	local point = lib.points.new({
+		coords = data.coords,
+		distance = 16,
+		invId = dropId,
+		instance = data.instance,
+		model = data.model
+	})
+
+	if point.model or client.dropprops then
+		point.distance = 30
+		point.onEnter = onEnterDrop
+		point.onExit = onExitDrop
+	else
+		point.nearby = nearbyDrop
+	end
+
+	client.drops[dropId] = point
+end
+
+RegisterNetEvent('ox_inventory:createDrop', function(dropId, data, owner, slot)
+	if client.drops then
+		createDrop(dropId, data)
+	end
+
+	if owner == cache.serverId then
+		if currentWeapon?.slot == slot then
+			currentWeapon = Weapon.Disarm(currentWeapon)
+		end
+
+		if invOpen and #(GetEntityCoords(playerPed) - data.coords) <= 1 then
+			if not cache.vehicle then
+				client.openInventory('drop', dropId)
+			else
+				SendNUIMessage({
+					action = 'setupInventory',
+					data = { rightInventory = currentInventory }
+				})
+			end
+		end
+	end
+end)
+
+RegisterNetEvent('ox_inventory:removeDrop', function(dropId)
+	if client.drops then
+		local point = client.drops[dropId]
+
+		if point then
+			client.drops[dropId] = nil
+			point:remove()
+
+			if point.entity then Utils.DeleteEntity(point.entity) end
+		end
+	end
+end)
+
+---@type function?
+local function setStateBagHandler(stateId)
+	AddStateBagChangeHandler('invOpen', stateId, function(_, _, value)
+		invOpen = value
+	end)
+
+	AddStateBagChangeHandler('invBusy', stateId, function(_, _, value)
+		invBusy = value
+	end)
+
+    AddStateBagChangeHandler('canUseWeapons', stateId, function(_, _, value)
+        if not value and currentWeapon then
+            currentWeapon = Weapon.Disarm(currentWeapon)
+        end
+    end)
+
+	AddStateBagChangeHandler('instance', stateId, function(_, _, value)
+		currentInstance = value
+
+		if client.drops then
+			-- Iterate over known drops and remove any points in a different instance (ignoring no instance)
+			for dropId, point in pairs(client.drops) do
+				if point.instance then
+					if point.instance ~= value then
+						if point.entity then
+							Utils.DeleteEntity(point.entity)
+							point.entity = nil
+						end
+
+						point:remove()
+					else
+						-- Recreate the drop using data from the old point
+						createDrop(dropId, point)
+					end
+				end
+			end
+		end
+	end)
+
+	AddStateBagChangeHandler('dead', stateId, function(_, _, value)
+		Utils.WeaponWheel()
+		PlayerData.dead = value
+	end)
+
+	AddStateBagChangeHandler('invHotkeys', stateId, function(_, _, value)
+		invHotkeys = value
+	end)
+
+	setStateBagHandler = nil
+end
+
+local waraus = false		--Holger added
+
+lib.onCache('seat', function(seat)
+	--Holgers part start
+	if currentWeapon then
+		Weapon.Disarm(currentWeapon,true)
+	end
+	Utils.ClearWeapons()
+	Utils.WeaponWheelsyncen()
+	--Holgers part stop
+	if seat then
+		local hasWeapon = GetCurrentPedVehicleWeapon(cache.ped)
+
+		if hasWeapon and not EnableWeaponWheel then  	--Holger added and not EnableWeaponWheel 
+			waraus = true								--Holger added
+			return Utils.WeaponWheel(true)
+		end
+	end
+
+	if waraus then --Holger added
+		Utils.WeaponWheel(false)
+		waraus = false	--Holger added
+	end		--Holger added
+end)
+
+lib.onCache('vehicle', function()
+	if invOpen and (not currentInventory.entity or currentInventory.entity == cache.vehicle) then
+		return client.closeInventory()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inventory, weight, player)
+	if source == '' then return end
+
+    ---@class PlayerData
+    ---@field inventory table<number, SlotWithItem?>
+    ---@field weight number
+    ---@field groups table<string, number>
+	PlayerData = player
+	PlayerData.id = cache.playerId
+	PlayerData.source = cache.serverId
+    PlayerData.maxWeight = shared.playerweight
+
+	setmetatable(PlayerData, {
+		__index = function(self, key)
+			if key == 'ped' then
+				return PlayerPedId()
+			end
+		end
+	})
+
+	if setStateBagHandler then setStateBagHandler(('player:%s'):format(cache.serverId)) end
+
+	local ItemData = table.create(0, #Items)
+
+	for _, v in pairs(Items --[[@as table<string, OxClientItem>]]) do
+		local buttons = v.buttons and {} or nil
+
+		if buttons then
+			for i = 1, #v.buttons do
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
+			end
+		end
+
+		ItemData[v.name] = {
+			label = v.label,
+			stack = v.stack,
+			close = v.close,
+			count = 0,
+			description = v.description,
+			buttons = buttons,
+			ammoName = v.ammoname,
+			image = v.client?.image
+		}
+	end
+
+	for _, data in pairs(inventory) do
+		local item = Items[data.name]
+
+		if item then
+			item.count += data.count
+			ItemData[data.name].count += data.count
+			local add = item.client?.add
+
+			if add then
+				add(item.count)
+			end
+		end
+	end
+
+	local phone = Items.phone
+
+	if phone and phone.count < 1 then
+		pcall(function()
+			return exports.npwd:setPhoneDisabled(true)
+		end)
+	end
+
+	client.setPlayerData('inventory', inventory)
+	client.setPlayerData('weight', weight)
+	currentWeapon = nil
+	Weapon.ClearAll()
+
+	local uiLocales = {}
+	local locales = lib.getLocales()
+
+	for k, v in pairs(locales) do
+		if k:find('^ui_')then
+			uiLocales[k] = v
+		end
+	end
+
+	uiLocales['$'] = locales['$']
+	uiLocales.ammo_type = locales.ammo_type
+
+	client.drops = currentDrops
+
+	for dropId, data in pairs(currentDrops) do
+		createDrop(dropId, data)
+	end
+
+	local hasTextUi
+	local uiOptions = { icon = 'fa-id-card' }
+
+	---@param point CPoint
+	local function nearbyLicense(point)
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, 0, true, false, false, false)
+
+		if point.isClosest and point.currentDistance < 1.2 then
+			if not hasTextUi then
+				hasTextUi = point
+				lib.showTextUI(point.message, uiOptions)
+			end
+
+			if IsControlJustReleased(0, 38) then
+				lib.callback('ox_inventory:buyLicense', 1000, function(success, message)
+					if success ~= nil then
+						lib.notify({
+							id = message,
+							type = success == false and 'error' or 'success',
+							description = locale(message, locale('license', point.type:gsub("^%l", string.upper)))
+						})
+					end
+				end, point.invId)
+			end
+		elseif hasTextUi == point then
+			hasTextUi = false
+			lib.hideTextUI()
+		end
+	end
+
+	for id, data in pairs(lib.load('data.licenses') or {}) do
+		lib.points.new({
+			coords = data.coords,
+			distance = 16,
+			inv = 'license',
+			type = data.name,
+			price = data.price,
+			invId = id,
+			nearby = nearbyLicense,
+			message = ('**%s**  \n%s'):format(locale('purchase_license', data.name), locale('interact_prompt', GetControlInstructionalButton(0, 38, true):sub(3)))
+		})
+	end
+
+	while not client.uiLoaded do Wait(50) end
+
+	SendNUIMessage({
+		action = 'init',
+		data = {
+			locale = uiLocales,
+			items = ItemData,
+			leftInventory = {
+				id = cache.playerId,
+				slots = shared.playerslots,
+				items = PlayerData.inventory,
+				maxWeight = shared.playerweight,
+			},
+			imagepath = client.imagepath
+		}
+	})
+
+	PlayerData.loaded = true
+
+	lib.notify({ description = locale('inventory_setup') })
+	Shops.refreshShops()
+	Inventory.Stashes()
+	Inventory.Evidence()
+
+	if registerCommands then registerCommands() end
+
+	TriggerEvent('ox_inventory:updateInventory', PlayerData.inventory)
+
+	client.interval = SetInterval(function()
+		if invOpen == false then
+			playerCoords = GetEntityCoords(playerPed)
+
+			if currentWeapon and IsPedUsingActionMode(playerPed) then
+				SetPedUsingActionMode(playerPed, false, -1, 'DEFAULT_ACTION')
+			end
+
+		elseif invOpen == true then
+			if not canOpenInventory() then
+				client.closeInventory()
+			else
+				playerCoords = GetEntityCoords(playerPed)
+
+				if currentInventory and not currentInventory.ignoreSecurityChecks then
+                    local maxDistance = (currentInventory.distance or currentInventory.type == 'stash' and 4.8 or 1.8) + 0.2
+
+					if currentInventory.type == 'otherplayer' then
+						local id = GetPlayerFromServerId(currentInventory.id)
+						local ped = GetPlayerPed(id)
+						local pedCoords = GetEntityCoords(ped)
+
+						if not id or #(playerCoords - pedCoords) > maxDistance or not (client.hasGroup(shared.police) or canOpenTarget(ped)) then
+							client.closeInventory()
+							lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+						else
+							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
+						end
+
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > maxDistance or canOpenTarget(playerPed)) then
+						client.closeInventory()
+						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+					end
+				end
+			end
+		end
+
+		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
+			Utils.DeleteEntity(client.parachute[1])
+			client.parachute = false
+		end
+--[[ 
+		if EnableWeaponWheel then return end
+
+		local weaponHash = GetSelectedPedWeapon(playerPed)
+
+		if currentWeapon then
+			if weaponHash ~= currentWeapon.hash and currentWeapon.timer then
+				local weaponCount = Items[currentWeapon.name]?.count
+
+				if weaponCount > 0 then
+					SetCurrentPedWeapon(playerPed, currentWeapon.hash, true)
+					SetAmmoInClip(playerPed, currentWeapon.hash, currentWeapon.metadata.ammo)
+					SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+
+					weaponHash = GetSelectedPedWeapon(playerPed)
+				end
+
+				if weaponHash ~= currentWeapon.hash then
+                    lib.print.info(('%s was forcibly unequipped (caused by game behaviour or another resource)'):format(currentWeapon.name))
+					currentWeapon = Weapon.Disarm(currentWeapon, true)
+				end
+			end
+		elseif client.weaponmismatch and not client.ignoreweapons[weaponHash] then
+			local weaponType = GetWeapontypeGroup(weaponHash)
+
+			if weaponType ~= 0 and weaponType ~= `GROUP_UNARMED` then
+				Weapon.Disarm(currentWeapon, true)
+			end
+		end ]] --disabled by Holger
+	end, 200)
+
+	local playerId = cache.playerId
+	local EnableKeys = client.enablekeys
+	local DisablePlayerVehicleRewards = DisablePlayerVehicleRewards
+	local DisableAllControlActions = DisableAllControlActions
+	local HideHudAndRadarThisFrame = HideHudAndRadarThisFrame
+	local EnableControlAction = EnableControlAction
+	local DisablePlayerFiring = DisablePlayerFiring
+	local HudWeaponWheelIgnoreSelection = HudWeaponWheelIgnoreSelection
+	local DisableControlAction = DisableControlAction
+	local IsPedShooting = IsPedShooting
+	local IsControlJustReleased = IsControlJustReleased
+	local IsControlPressed = IsControlPressed		--added by Holger
+	local IsDisabledControlPressed = IsDisabledControlPressed		--added by Holger
+	local hotbartasten = {157,158,160,164,165}		--added by Holger
+
+	client.tick = SetInterval(function()
+		DisablePlayerVehicleRewards(playerId)
+		local sleep = 100		--sleep by Holger
+
+		if invOpen then
+			sleep = 0
+			DisableAllControlActions(0)
+			HideHudAndRadarThisFrame()
+
+			for i = 1, #EnableKeys do
+				EnableControlAction(0, EnableKeys[i], true)
+			end
+
+			if currentInventory.type == 'newdrop' then
+				EnableControlAction(0, 30, true)
+				EnableControlAction(0, 31, true)
+			end
+		else
+			if invBusy then
+				DisableControlAction(0, 23, true)
+				DisableControlAction(0, 36, true)
+				sleep = 0
+			end
+
+			if usingItem or invOpen or IsPedCuffed(playerPed) then
+				DisablePlayerFiring(playerId, true)
+				sleep = 0
+			end
+
+			if not EnableWeaponWheel then
+				HudWeaponWheelIgnoreSelection()
+				DisableControlAction(0, 37, true)
+				sleep = 0
+			end
+
+			if HotbarundWeaponWheel then--by Holger
+				sleep = 0
+				for i = 1, #hotbartasten do
+					if IsControlPressed(0, hotbartasten[i]) or IsDisabledControlPressed(0,hotbartasten[i]) then
+						DisableControlAction(0, hotbartasten[i], true)
+					end
+				end
+			end--by Holger
+
+			if currentWeapon and currentWeapon.timer then
+				sleep = 0
+				DisableControlAction(0, 80, true)
+				DisableControlAction(0, 140, true)
+
+				if currentWeapon.metadata.durability <= 0 or not currentWeapon.timer then
+					DisablePlayerFiring(playerId, true)
+				elseif client.aimedfiring and not currentWeapon.melee and currentWeapon.group ~= `GROUP_PETROLCAN` and not IsPlayerFreeAiming(playerId) then
+					DisablePlayerFiring(playerId, true)
+				end
+
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if not invBusy and currentWeapon.timer ~= 0 and currentWeapon.timer < GetGameTimer() then
+					currentWeapon.timer = 0
+
+					if weaponAmmo then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo)
+
+						if client.autoreload and currentWeapon.ammo and GetAmmoInPedWeapon(playerPed, currentWeapon.hash) == 0 then
+							local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+							if slotId then
+								CreateThread(function() useSlot(slotId) end)
+							end
+						end
+
+					elseif currentWeapon.metadata.durability then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'melee', currentWeapon.melee)
+						currentWeapon.melee = 0
+					end
+				elseif weaponAmmo then
+					if IsPedShooting(playerPed) then
+						local currentAmmo
+						local durabilityDrain = Items[currentWeapon.name].durability
+
+						if currentWeapon.group == `GROUP_PETROLCAN` or currentWeapon.group == `GROUP_FIREEXTINGUISHER` then
+							currentAmmo = weaponAmmo - durabilityDrain < 0 and 0 or weaponAmmo - durabilityDrain
+							currentWeapon.metadata.durability = currentAmmo
+							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+
+							if currentAmmo <= 0 then
+								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+							end
+						else
+							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+
+							if currentAmmo < weaponAmmo then
+								currentAmmo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+								currentWeapon.metadata.ammo = currentAmmo
+								currentWeapon.metadata.durability = currentWeapon.metadata.durability - (durabilityDrain * math.abs((weaponAmmo or 0.1) - currentAmmo))
+							end
+						end
+
+						if currentAmmo <= 0 then
+							if cache.vehicle then
+								TaskSwapWeapon(playerPed, true)
+							end
+
+							currentWeapon.timer = GetGameTimer() + 200
+						else currentWeapon.timer = GetGameTimer() + (GetWeaponTimeBetweenShots(currentWeapon.hash) * 1000) + 100 end
+					end
+				elseif currentWeapon.throwable then
+					if not invBusy and IsControlPressed(0, 24) then
+						invBusy = 1
+
+						CreateThread(function()
+							local weapon = currentWeapon
+
+							while currentWeapon and (not IsPedWeaponReadyToShoot(cache.ped) or IsDisabledControlPressed(0, 24)) and GetSelectedPedWeapon(playerPed) == weapon.hash do
+								Wait(0)
+							end
+
+							if GetSelectedPedWeapon(playerPed) == weapon.hash then Wait(700) end
+
+							while IsPedPlantingBomb(playerPed) do Wait(0) end
+
+							TriggerServerEvent('ox_inventory:updateWeapon', 'throw', nil, weapon.slot)
+							plyState:set('invBusy', false, true)
+
+							currentWeapon = nil
+
+							RemoveWeaponFromPed(playerPed, weapon.hash)
+							TriggerEvent('ox_inventory:currentWeapon')
+						end)
+					end
+				elseif currentWeapon.melee and IsControlJustReleased(0, 24) and IsPedPerformingMeleeAction(playerPed) then
+					currentWeapon.melee += 1
+					currentWeapon.timer = GetGameTimer() + 200
+				end
+			end
+		end		
+		if sleep > 0 then --- sleep by Holger
+			Wait(sleep)
+		end
+	end)
+
+	plyState:set('invBusy', false, true)
+	plyState:set('invOpen', false, false)
+	plyState:set('invHotkeys', true, false)
+	plyState:set('canUseWeapons', true, false)
+	collectgarbage('collect')
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if shared.resource == resourceName then
+		client.onLogout()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then TriggerScreenblurFadeIn(0) end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+    currentInventory.type = 'inspect'
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+RegisterNUICallback('uiLoaded', function(_, cb)
+	client.uiLoaded = true
+	cb(1)
+end)
+
+RegisterNUICallback('getItemData', function(itemName, cb)
+	cb(Items[itemName])
+end)
+
+RegisterNUICallback('removeComponent', function(data, cb)
+	cb(1)
+
+	if not currentWeapon then
+		return TriggerServerEvent('ox_inventory:updateWeapon', 'component', data)
+	end
+
+	if data.slot ~= currentWeapon.slot then
+		return lib.notify({ id = 'weapon_hand_wrong', type = 'error', description = locale('weapon_hand_wrong') })
+	end
+
+	local itemSlot = PlayerData.inventory[currentWeapon.slot]
+
+    if not itemSlot then return end
+
+	for _, component in pairs(Items[data.component].client.component) do
+		if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+			for k, v in pairs(itemSlot.metadata.components) do
+				if v == data.component then
+					local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', k)
+
+					if success then
+						RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, component)
+						TriggerEvent('ox_inventory:updateWeaponComponent', 'removed', component, data.component)
+					end
+
+					break
+				end
+			end
+		end
+	end
+end)
+
+RegisterNUICallback('removeAmmo', function(slot, cb)
+	cb(1)
+	local slotData = PlayerData.inventory[slot]
+
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo == 0 then return end
+
+	local success = lib.callback.await('ox_inventory:removeAmmoFromWeapon', false, slot)
+
+	if success and slot == currentWeapon?.slot then
+		SetPedAmmo(playerPed, currentWeapon.hash, 0)
+	end
+end)
+
+RegisterNUICallback('useItem', function(slot, cb)
+	useSlot(slot --[[@as number]])
+	cb(1)
+end)
+
+local function giveItemToTarget(serverId, slotId, count)
+    if type(slotId) ~= 'number' then return TypeError('slotId', 'number', type(slotId)) end
+    if count and type(count) ~= 'number' then return TypeError('count', 'number', type(count)) end
+
+    if slotId == currentWeapon?.slot then
+        currentWeapon = Weapon.Disarm(currentWeapon)
+    end
+
+    Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 1.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+
+    local notification = lib.callback.await('ox_inventory:giveItem', false, slotId, serverId, count or 0)
+
+    if notification then
+        lib.notify({ type = 'error', description = locale(table.unpack(notification)) })
+    end
+end
+
+exports('giveItemToTarget', giveItemToTarget)
+
+local function isGiveTargetValid(ped, coords)
+    if cache.vehicle and GetVehiclePedIsIn(ped, false) == cache.vehicle then
+        return true
+    end
+
+    local entity = Utils.Raycast(1|2|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
+
+    return entity == ped and IsEntityVisible(ped)
+end
+
+RegisterNUICallback('giveItem', function(data, cb)
+	cb(1)
+
+    if usingItem then return end
+
+	if client.giveplayerlist then
+		local nearbyPlayers = lib.getNearbyPlayers(GetEntityCoords(playerPed), 3.0)
+        local nearbyCount = #nearbyPlayers
+
+		if nearbyCount == 0 then return end
+
+        if nearbyCount == 1 then
+			local option = nearbyPlayers[1]
+
+            if not isGiveTargetValid(option.ped, option.coords) then return end
+
+            return giveItemToTarget(GetPlayerServerId(option.id), data.slot, data.count)
+        end
+
+        local giveList, n = {}, 0
+
+		for i = 1, #nearbyPlayers do
+			local option = nearbyPlayers[i]
+
+            if isGiveTargetValid(option.ped, option.coords) then
+				local playerName = GetPlayerName(option.id)
+				option.id = GetPlayerServerId(option.id)
+                ---@diagnostic disable-next-line: inject-field
+				option.label = ('[%s] %s'):format(option.id, playerName)
+				n += 1
+				giveList[n] = option
+			end
+		end
+
+        if n == 0 then return end
+
+		lib.registerMenu({
+			id = 'ox_inventory:givePlayerList',
+			title = 'Give item',
+			options = giveList,
+		}, function(selected)
+            giveItemToTarget(giveList[selected].id, data.slot, data.count)
+        end)
+
+		return lib.showMenu('ox_inventory:givePlayerList')
+	end
+
+    if cache.vehicle then
+		local seats = GetVehicleMaxNumberOfPassengers(cache.vehicle) - 1
+
+		if seats >= 0 then
+			local passenger = GetPedInVehicleSeat(cache.vehicle, cache.seat - 2 * (cache.seat % 2) + 1)
+
+			if passenger ~= 0 and IsEntityVisible(passenger) then
+                return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(passenger)), data.slot, data.count)
+			end
+		end
+
+        return
+	end
+
+    local entity = Utils.Raycast(1|2|4|8|16, GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 3.0, 0.5), 0.2)
+
+    if entity and IsPedAPlayer(entity) and IsEntityVisible(entity) and #(GetEntityCoords(playerPed, true) - GetEntityCoords(entity, true)) < 3.0 then
+        return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(entity)), data.slot, data.count)
+    end
+end)
+
+RegisterNUICallback('useButton', function(data, cb)
+	useButton(data.id, data.slot)
+	cb(1)
+end)
+
+RegisterNUICallback('exit', function(_, cb)
+	client.closeInventory()
+	cb(1)
+end)
+
+lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
+	recipe = CraftingBenches[id].items[recipe]
+
+	return lib.progressCircle({
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
+		duration = recipe.duration or 3000,
+		canCancel = true,
+		disable = {
+			move = true,
+			combat = true,
+		},
+		anim = {
+			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+			clip = 'machinic_loop_mechandplayer',
+		}
+	})
+end)
+
+local swapActive = false
+
+---Synchronise and validate all item movement between the NUI and server.
+RegisterNUICallback('swapItems', function(data, cb)
+    if swapActive or not invOpen or invBusy or usingItem then return cb(false) end
+
+    swapActive = true
+
+	if data.toType == 'newdrop' then
+		if cache.vehicle or IsPedFalling(playerPed) then
+			swapActive = false
+			return cb(false)
+		end
+
+		local coords = GetEntityCoords(playerPed)
+
+		if IsEntityInWater(playerPed) then
+			local destination = vec3(coords.x, coords.y, -200)
+			local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z, 511, cache.ped, 4)
+
+			while true do
+				Wait(0)
+				local retval, hit, endCoords = GetShapeTestResult(handle)
+
+				if retval ~= 1 then
+					if not hit then return end
+
+					data.coords = vec3(endCoords.x, endCoords.y, endCoords.z + 1.0)
+
+					break
+				end
+			end
+		else
+			data.coords = coords
+		end
+    end
+
+	if currentInstance then
+		data.instance = currentInstance
+	end
+
+	if currentWeapon and data.fromType ~= data.toType then
+		if (data.fromType == 'player' and data.fromSlot == currentWeapon.slot) or (data.toType == 'player' and data.toSlot == currentWeapon.slot) then
+			currentWeapon = Weapon.Disarm(currentWeapon, true)
+		end
+	end
+
+	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
+    swapActive = false
+
+	cb(success or false)
+
+	if success then
+        if weaponSlot and currentWeapon then
+            currentWeapon.slot = weaponSlot
+        end
+
+		if response then
+			updateInventory(response.items, response.weight)
+		end
+	elseif response then
+		if type(response) == 'table' then
+			SendNUIMessage({ action = 'refreshSlots', data = { items = response } })
+		else
+			lib.notify({ type = 'error', description = locale(response) })
+		end
+	end
+end)
+
+RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
+	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
+
+	if data then
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
+	end
+
+	if message then
+		lib.notify(message)
+	end
+
+	cb(response)
+end)
+
+RegisterNUICallback('craftItem', function(data, cb)
+	cb(true)
+
+	local id, index = currentInventory.id, currentInventory.index
+
+	for i = 1, data.count do
+		local success, response = lib.callback.await('ox_inventory:craftItem', 200, id, index, data.fromSlot, data.toSlot)
+
+		if not success then
+			if response then lib.notify({ type = 'error', description = locale(response or 'cannot_perform') }) end
+			break
+		end
+	end
+
+	if not currentInventory or currentInventory.type ~= 'crafting' then
+		client.openInventory('crafting', { id = id, index = index })
+	end
+end)
+
+lib.callback.register('ox_inventory:getVehicleData', function(netid)
+	local entity = NetworkGetEntityFromNetworkId(netid)
+
+	if entity then
+		return GetEntityModel(entity), GetVehicleClass(entity)
+	end
+end)
+
+
+
+
+
+
+-----------------HOLGERS Anpassungen------------------
+CreateThread(function()
+	local hash 
+	while true do
+		if EnableWeaponWheel and not Utils.Waffensyncaus then
+			local  temphash = GetSelectedPedWeapon(cache.ped)
+			if hash ~= temphash then
+				if Waffencache[temphash] then
+					useSlot(Waffencache[temphash].slot,"lurchig",true)
+					Wait(100)
+				else	
+					if temphash ~= -1569615261 and Weapon.WeaponByHash[temphash] then
+						RemoveWeaponFromPed(cache.ped, temphash)
+					elseif currentWeapon then
+						currentWeapon = Weapon.Disarm(currentWeapon,false,true)
+						--Wait(100)
+					end
+				end
+				hash = temphash
+			end
+		elseif Utils.Waffensyncaus then
+			local  temphash = GetSelectedPedWeapon(cache.ped)			
+			if hash ~= temphash then
+				if temphash ~= -1569615261 and hash ~= -1569615261  and Weapon.WeaponByHash[temphash] then
+					Weapon.triggerAnimation(hash,temphash,false)
+					Weapon.triggerAnimation(hash,temphash,true)
+				elseif hash == -1569615261 and temphash ~= -1569615261 and Weapon.WeaponByHash[temphash] then
+					Weapon.triggerAnimation(hash,temphash,true)
+				elseif temphash == -1569615261 then
+					Weapon.triggerAnimation(hash,temphash,false)					
+					GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+				end
+				hash = temphash
+			end
+		else
+			Wait(900)
+		end
+
+		Wait(100)
+	end
+
+end)
+
+
+
+
+
+
+
+-----------------HOLGERS Anpassungen bis hier------------------

--- a/2.43.3/modules/utils/client.lua
+++ b/2.43.3/modules/utils/client.lua
@@ -1,0 +1,258 @@
+if not lib then return end
+
+local Utils = {}
+
+Utils.Waffensyncaus = false     --added by Holger
+
+
+function Utils.PlayAnim(wait, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(cache.ped, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+                                time)
+    lib.requestAnimDict(dict)
+    TaskPlayAnimAdvanced(cache.ped, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+        time, 0, 0)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+---@param flag number
+---@param destination? vector3
+---@param size? number
+---@return number | false
+---@return number?
+function Utils.Raycast(flag, destination, size)
+    local playerCoords = GetEntityCoords(cache.ped)
+    destination = destination or GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)
+    local rayHandle = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x,
+        destination.y, destination.z, size or 2.2, flag or 30, cache.ped, 4)
+    while true do
+        Wait(0)
+        local result, _, coords, _, entityHit = GetShapeTestResult(rayHandle)
+        if result ~= 1 then
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x, destination.y, destination.z, 0, 0, 255, 255)
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, coords.x, coords.y, coords.z, 255, 0, 0, 255)
+            local entityType
+            if entityHit then entityType = GetEntityType(entityHit) end
+            if entityHit and entityType ~= 0 then
+                return entityHit, entityType
+            end
+            return false
+        end
+    end
+end
+
+function Utils.GetClosestPlayer()
+    local players = GetActivePlayers()
+    local playerCoords = GetEntityCoords(cache.ped)
+    local targetDistance, targetId, targetPed
+
+    for i = 1, #players do
+        local player = players[i]
+
+        if player ~= cache.playerId then
+            local ped = GetPlayerPed(player)
+            local distance = #(playerCoords - GetEntityCoords(ped))
+
+            if distance < (targetDistance or 2) then
+                targetDistance = distance
+                targetId = player
+                targetPed = ped
+            end
+        end
+    end
+
+    return targetId, targetPed
+end
+
+-- Replace ox_inventory notify with ox_lib (backwards compatibility)
+function Utils.Notify(data)
+    data.description = data.text
+    data.text = nil
+    lib.notify(data)
+end
+
+RegisterNetEvent('ox_inventory:notify', Utils.Notify)
+exports('notify', Utils.Notify)
+
+function Utils.ItemNotify(data)
+    if not client.itemnotify then
+        return
+    end
+
+    SendNUIMessage({ action = 'itemNotify', data = data })
+end
+
+RegisterNetEvent('ox_inventory:itemNotify', Utils.ItemNotify)
+
+---@deprecated
+function Utils.DeleteObject(obj)
+    SetEntityAsMissionEntity(obj, false, true)
+    DeleteObject(obj)
+end
+
+function Utils.DeleteEntity(entity)
+    if DoesEntityExist(entity) then
+        SetEntityAsMissionEntity(entity, false, true)
+        DeleteEntity(entity)
+    end
+end
+
+local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
+
+-- Enables the weapon wheel, but disables the use of inventory weapons.
+-- Mostly used for weaponised vehicles, though could be called for "minigames"
+
+
+EnableWeaponWheel = true        --added by Holger
+SetWeaponsNoAutoswap(true)      --added by Holger
+SetWeaponsNoAutoreload(true)    --added by Holger
+function Utils.WeaponWheel(state)
+    if client.disableweapons then state = true end
+    if state == nil then state = EnableWeaponWheel end
+
+    EnableWeaponWheel = state
+    SetWeaponsNoAutoswap(not state)
+    SetWeaponsNoAutoreload(not state)
+    Utils.WeaponWheelsyncen()       --added by Holger
+
+    if client.suppresspickups then
+        -- CLEAR_PICKUP_REWARD_TYPE_SUPPRESSION | SUPPRESS_PICKUP_REWARD_TYPE
+        return state and N_0x762db2d380b48d04(rewardTypes) or N_0xf92099527db8e2a7(rewardTypes, true)
+    end
+end
+
+--Holgers part starts
+
+
+function Utils.Waffensyncdisable(state)
+	if state == nil then state = Utils.Waffensyncaus end
+	Utils.Waffensyncaus = state
+	Utils.WeaponWheelsyncen()
+end
+
+Utils.WeaponWheelundHotbar = function(state)
+	if state == nil then state = HotbarundWeaponWheel end
+	HotbarundWeaponWheel = state
+	Utils.WeaponWheel(state)
+end
+
+Utils.WeaponWheelsyncen = function ()
+	Utils.ClearWeapons()
+	if not Utils.Waffensyncaus then		
+		Wait(500)
+		local items = exports.ox_inventory:GetPlayerItems()
+		if items ~=nil  then
+			Waffencache = nil
+			Waffencache = {}
+			for k,v in pairs(items) do
+				if string.sub(v.name,1,7) =="WEAPON_"  and v.name ~= "WEAPON_PETROLCAN" then
+					if HasPedGotWeapon(cache.ped,v.name,false) then
+						RemoveWeaponFromPed(cache.ped,v.name)
+					end
+					local hash = GetHashKey(v.name)
+					Waffencache[hash] = {}
+					Waffencache[hash].name = v.name
+					Waffencache[hash].slot = v.slot
+					Waffencache[hash].hash = hash
+
+					GiveWeaponToPed(cache.ped,v.name,1,false,false)
+				end
+			end
+		end
+	end
+end
+
+
+
+exports('weaponWheel', Utils.WeaponWheel)
+exports('Weaponsyncdisable', Utils.Waffensyncdisable)
+--Holgers part ends
+exports('WeaponWheelandHotbar', Utils.WeaponWheelundHotbar)
+
+function Utils.CreateBlip(settings, coords)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, settings.id)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, settings.scale)
+    SetBlipColour(blip, settings.colour)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName(settings.name)
+    EndTextCommandSetBlipName(blip)
+
+    return blip
+end
+
+---Takes OxTargetBoxZone or legacy zone data (PolyZone) and creates a zone.
+---@param data OxTargetBoxZone | { length: number, minZ: number, maxZ: number, loc: vector3, heading: number, width: number, distance: number }
+---@param options? OxTargetOption[]
+---@return number
+function Utils.CreateBoxZone(data, options)
+    if data.length then
+        local height = math.abs(data.maxZ - data.minZ)
+        local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2
+        data.coords = vec3(data.loc.x, data.loc.y, z)
+        data.size = vec3(data.width, data.length, height)
+        data.rotation = data.heading
+        data.loc = nil
+        data.heading = nil
+        data.length = nil
+        data.width = nil
+        data.maxZ = nil
+        data.minZ = nil
+    end
+
+    if not data.options and options then
+        local distance = data.distance or 2.0
+
+        for k, v in pairs(options) do
+            if not v.distance then
+                v.distance = distance
+            end
+        end
+
+        data.options = options
+    end
+
+    return exports.ox_target:addBoxZone(data)
+end
+
+local hasTextUi
+
+---@param point CPoint
+function Utils.nearbyMarker(point)
+    DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15,
+        ---@diagnostic disable-next-line: param-type-mismatch
+        point.marker[1], point.marker[2], point.marker[3], 222, false, false, 0, true, false, false, false)
+
+    if point.isClosest and point.currentDistance < 1.2 then
+        if not hasTextUi then
+            hasTextUi = point
+            lib.showTextUI(point.prompt.message, point.prompt.options)
+        end
+
+        if IsControlJustReleased(0, 38) then
+            CreateThread(function()
+                if point.inv == 'policeevidence' then
+                    client.openInventory('policeevidence')
+                elseif point.inv == 'crafting' then
+                    client.openInventory('crafting', { id = point.benchid, index = point.index })
+                else
+                    client.openInventory(point.inv or 'drop', { id = point.invId, type = point.type })
+                end
+            end)
+        end
+    elseif hasTextUi == point then
+        hasTextUi = nil
+        lib.hideTextUI()
+    end
+end
+
+return Utils

--- a/2.43.3/modules/weapon/client.lua
+++ b/2.43.3/modules/weapon/client.lua
@@ -1,0 +1,652 @@
+if not lib then return end
+
+local Weapon = {}
+local Items = require 'modules.items.client'
+local Utils = require 'modules.utils.client'
+
+-- generic group animation data
+local anims = {}
+anims[`GROUP_MELEE`] = { 'melee@holster', 'unholster', 200, 'melee@holster', 'holster', 600 }
+anims[`GROUP_PISTOL`] = { 'reaction@intimidation@cop@unarmed', 'intro', 400, 'reaction@intimidation@cop@unarmed', 'outro', 450 }
+anims[`GROUP_STUNGUN`] = anims[`GROUP_PISTOL`]
+
+local function vehicleIsCycle(vehicle)
+	local class = GetVehicleClass(vehicle)
+	return class == 8 or class == 13
+end
+
+function Weapon.Equip(item, data, noWeaponAnim)
+	local playerPed = cache.ped
+	local coords = GetEntityCoords(playerPed, true)
+    local sleep
+
+	if client.weaponanims then
+		if noWeaponAnim or (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			goto skipAnim
+		end
+
+		local anim = data.anim or anims[GetWeapontypeGroup(data.hash)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+		sleep = anim and anim[3] or 1200
+		
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)--added by Holger
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+	end 
+
+	::skipAnim::
+
+	item.hash = data.hash
+	item.ammo = data.ammoname
+	item.melee = GetWeaponDamageType(data.hash) == 2 and 0
+	item.timer = 0
+	item.throwable = data.throwable
+	item.group = GetWeapontypeGroup(item.hash)
+
+	GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+
+	if item.metadata.tint then SetPedWeaponTintIndex(playerPed, data.hash, item.metadata.tint) end
+
+	if item.metadata.components then
+		for i = 1, #item.metadata.components do
+			local components = Items[item.metadata.components[i]].client.component
+			for v=1, #components do
+				local component = components[v]
+				if DoesWeaponTakeWeaponComponent(data.hash, component) then
+					if not HasPedGotWeaponComponent(playerPed, data.hash, component) then
+						GiveWeaponComponentToPed(playerPed, data.hash, component)
+					end
+				end
+			end
+		end
+	end
+
+	if item.metadata.specialAmmo then
+		local clipComponentKey = ('%s_CLIP'):format(data.model:gsub('WEAPON_', 'COMPONENT_'))
+		local specialClip = ('%s_%s'):format(clipComponentKey, item.metadata.specialAmmo:upper())
+
+		if DoesWeaponTakeWeaponComponent(data.hash, specialClip) then
+			GiveWeaponComponentToPed(playerPed, data.hash, specialClip)
+		end
+	end
+
+	local ammo = item.metadata.ammo or item.throwable and 1 or 0
+
+	SetCurrentPedWeapon(playerPed, data.hash, true)
+	SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+	SetWeaponsNoAutoswap(true)
+	SetPedAmmo(playerPed, data.hash, ammo)
+	SetTimeout(0, function() RefillAmmoInstantly(playerPed) end)
+
+	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
+		item.metadata.ammo = item.metadata.durability
+		SetPedInfiniteAmmo(playerPed, true, data.hash)
+	end
+
+	TriggerEvent('ox_inventory:currentWeapon', item)
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
+
+	return item, sleep
+end
+
+function Weapon.Disarm(currentWeapon, noAnim, waffenlos) --waffenlos added by Holger
+	if currentWeapon?.timer then
+		currentWeapon.timer = nil
+
+        TriggerServerEvent('ox_inventory:updateWeapon')
+		--SetPedAmmo(cache.ped, currentWeapon.hash, 0)		--disabled by Holger
+
+		if client.weaponanims and not noAnim then
+			if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+				goto skipAnim
+			end
+
+			ClearPedSecondaryTask(cache.ped)
+
+			local item = Items[currentWeapon.name]
+			local coords = GetEntityCoords(cache.ped, true)
+			local anim = item.anim or anims[GetWeapontypeGroup(currentWeapon.hash)]
+
+			if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+				anim = nil
+			end
+
+			local sleep = anim and anim[6] or 1400
+
+			
+			if waffenlos then		--if added by Holger
+				GiveWeaponToPed(cache.ped, currentWeapon.hash, 0, false, true)
+			end
+
+			Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+		end
+
+		::skipAnim::
+
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
+		TriggerEvent('ox_inventory:currentWeapon')
+	end
+
+--[[ 	Utils.WeaponWheel() --disabled by Holger
+	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
+	end ]]
+end
+
+
+--Holgers part starts
+
+
+Weapon.triggerAnimation = function(waffenhashalt,waffenhashneu,wert)
+	if wert then
+		local playerPed = cache.ped
+		local coords = GetEntityCoords(playerPed, true)
+		local sleep
+
+		if  (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			return
+		end
+
+		local anim = anims[GetWeapontypeGroup(waffenhashneu)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+
+		sleep = anim and anim[3] or 1100
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+
+		GiveWeaponToPed(playerPed, waffenhashneu, 250, false, true)
+		sleep = 0
+
+	else
+		if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+			return
+		end
+		local sleep
+
+
+		ClearPedSecondaryTask(cache.ped)
+
+		local coords = GetEntityCoords(cache.ped, true)
+		local anim = anims[GetWeapontypeGroup(waffenhashalt)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		local sleep = anim and anim[6] or 1000
+
+		GiveWeaponToPed(cache.ped, waffenhashalt, 0, false, true)
+		
+		Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+	end
+
+end
+
+--Holgers part ends
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+--added by Holger thanks to 5Labs for providing the list
+
+Weapon.WeaponByHash = {
+	[-1768145561] = {
+	["name"] = 'WEAPON_SPECIALCARBINE_MK2',
+	["label"] = 'Special Carbine MK2',
+	},
+	[487013001] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN',
+	["label"] = 'Pump Shotgun',
+	},
+	[-1075685676] = {
+	["name"] = 'WEAPON_PISTOL_MK2',
+	["label"] = 'Pistol MK2',
+	},
+	[-1238556825] = {
+	["name"] = 'WEAPON_RAYMINIGUN',
+	["label"] = 'Widowmaker',
+	},
+	[-1834847097] = {
+	["name"] = 'WEAPON_DAGGER',
+	["label"] = 'Dagger',
+	},
+	[-2067956739] = {
+	["name"] = 'WEAPON_CROWBAR',
+	["label"] = 'Crowbar',
+	},
+	[650961374] = {
+	["name"] = 'WEAPON_TEARGAS',
+	["label"] = 'Tear Gas',
+	},
+	[-618237638] = {
+	["name"] = 'WEAPON_EMPLAUNCHER',
+	["label"] = 'Compact EMP Launcher',
+	},
+	[-2084633992] = {
+	["name"] = 'WEAPON_CARBINERIFLE',
+	["label"] = 'Carbine Rifle',
+	},
+	[940833800] = {
+	["name"] = 'WEAPON_STONE_HATCHET',
+	["label"] = 'Stone Hatchet',
+	},
+	[-1716589765] = {
+	["name"] = 'WEAPON_PISTOL50',
+	["label"] = 'Pistol .50',
+	},
+	[-1716189206] = {
+	["name"] = 'WEAPON_KNIFE',
+	["label"] = 'Knife',
+	},
+	[1853742572] = {
+	["name"] = 'WEAPON_PRECISIONRIFLE',
+	["label"] = 'Precision Rifle',
+	},
+	[-1076751822] = {
+	["name"] = 'WEAPON_SNSPISTOL',
+	["label"] = 'SNS Pistol',
+	},
+	[1198879012] = {
+	["name"] = 'WEAPON_FLAREGUN',
+	["label"] = 'Flare Gun',
+	},
+	[-1355376991] = {
+	["name"] = 'WEAPON_RAYPISTOL',
+	["label"] = 'Up-n-Atomizer',
+	},
+	[-1813897027] = {
+	["name"] = 'WEAPON_GRENADE',
+	["label"] = 'Grenade',
+	},
+	[1737195953] = {
+	["name"] = 'WEAPON_NIGHTSTICK',
+	["label"] = 'Nightstick',
+	},
+	[1198256469] = {
+	["name"] = 'WEAPON_RAYCARBINE',
+	["label"] = 'Unholy Hellbringer',
+	},
+	[465894841] = {
+	["name"] = 'WEAPON_PISTOLXM3',
+	["label"] = 'WM 29 Pistol',
+	},
+	[1432025498] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN_MK2',
+	["label"] = 'Pump Shotgun MK2',
+	},
+	[100416529] = {
+	["name"] = 'WEAPON_SNIPERRIFLE',
+	["label"] = 'Sniper Rifle',
+	},
+	[1593441988] = {
+	["name"] = 'WEAPON_COMBATPISTOL',
+	["label"] = 'Glock',
+	},
+	[-581044007] = {
+	["name"] = 'WEAPON_MACHETE',
+	["label"] = 'Machete',
+	},
+	[-275439685] = {
+	["name"] = 'WEAPON_DBSHOTGUN',
+	["label"] = 'Double Barrel Shotgun',
+	},
+	[-1063057011] = {
+	["name"] = 'WEAPON_SPECIALCARBINE',
+	["label"] = 'Special Carbine',
+	},
+	[-1951375401] = {
+	["name"] = 'WEAPON_FLASHLIGHT',
+	["label"] = 'Flashlight',
+	},
+	[727643628] = {
+	["name"] = 'WEAPON_CERAMICPISTOL',
+	["label"] = 'Ceramic Pistol',
+	},
+	[584646201] = {
+	["name"] = 'WEAPON_APPISTOL',
+	["label"] = 'AP Pistol',
+	},
+	[-1045183535] = {
+	["name"] = 'WEAPON_REVOLVER',
+	["label"] = 'Revolver',
+	},
+	[-22923932] = {
+	["name"] = 'WEAPON_RAILGUNXM3',
+	["label"] = 'Railgun XM3',
+	},
+	[324215364] = {
+	["name"] = 'WEAPON_MICROSMG',
+	["label"] = 'Micro SMG',
+	},
+	[-1600701090] = {
+	["name"] = 'WEAPON_BZGAS',
+	["label"] = 'BZ Gas',
+	},
+	[-1168940174] = {
+	["name"] = 'WEAPON_HAZARDCAN',
+	["label"] = 'Hazard Can',
+	},
+	[-608341376] = {
+	["name"] = 'WEAPON_COMBATMG_MK2',
+	["label"] = 'Combat MG MK2',
+	},
+	[-538741184] = {
+	["name"] = 'WEAPON_SWITCHBLADE',
+	["label"] = 'Switchblade',
+	},
+	[984333226] = {
+	["name"] = 'WEAPON_HEAVYSHOTGUN',
+	["label"] = 'Heavy Shotgun',
+	},
+	[1785463520] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE_MK2',
+	["label"] = 'Marksman Rifle MK2',
+	},
+	[2024373456] = {
+	["name"] = 'WEAPON_SMG_MK2',
+	["label"] = 'SMG Mk2',
+	},
+	[1649403952] = {
+	["name"] = 'WEAPON_COMPACTRIFLE',
+	["label"] = 'Compact Rifle',
+	},
+	[615608432] = {
+	["name"] = 'WEAPON_MOLOTOV',
+	["label"] = 'Molotov',
+	},
+	[600439132] = {
+	["name"] = 'WEAPON_BALL',
+	["label"] = 'Ball',
+	},
+	[-952879014] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE',
+	["label"] = 'Marksman Rifle',
+	},
+	[-610080759] = {
+	["name"] = 'WEAPON_METALDETECTOR',
+	["label"] = 'Metal Detector',
+	},
+	[2017895192] = {
+	["name"] = 'WEAPON_SAWNOFFSHOTGUN',
+	["label"] = 'Sawn Off Shotgun',
+	},
+	[-1568386805] = {
+	["name"] = 'WEAPON_GRENADELAUNCHER',
+	["label"] = 'Grenade Launcher',
+	},
+	[-270015777] = {
+	["name"] = 'WEAPON_ASSAULTSMG',
+	["label"] = 'Assault SMG',
+	},
+	[-1466123874] = {
+	["name"] = 'WEAPON_MUSKET',
+	["label"] = 'Musket',
+	},
+	[-37975472] = {
+	["name"] = 'WEAPON_SMOKEGRENADE',
+	["label"] = 'Smoke Grenade',
+	},
+	[-1654528753] = {
+	["name"] = 'WEAPON_BULLPUPSHOTGUN',
+	["label"] = 'Bullpup Shotgun',
+	},
+	[1317494643] = {
+	["name"] = 'WEAPON_HAMMER',
+	["label"] = 'Hammer',
+	},
+	[137902532] = {
+	["name"] = 'WEAPON_VINTAGEPISTOL',
+	["label"] = 'Vintage Pistol',
+	},
+	[-853065399] = {
+	["name"] = 'WEAPON_BATTLEAXE',
+	["label"] = 'Battle Axe',
+	},
+	[-1660422300] = {
+	["name"] = 'WEAPON_MG',
+	["label"] = 'Machine Gun',
+	},
+	[1470379660] = {
+	["name"] = 'WEAPON_GADGETPISTOL',
+	["label"] = 'Perico Pistol',
+	},
+	[-1853920116] = {
+	["name"] = 'WEAPON_NAVYREVOLVER',
+	["label"] = 'Navy Revolver',
+	},
+	[94989220] = {
+	["name"] = 'WEAPON_COMBATSHOTGUN',
+	["label"] = 'Combat Shotgun',
+	},
+	[2144741730] = {
+	["name"] = 'WEAPON_COMBATMG',
+	["label"] = 'Combat MG',
+	},
+	[317205821] = {
+	["name"] = 'WEAPON_AUTOSHOTGUN',
+	["label"] = 'Sweeper Shotgun',
+	},
+	[883325847] = {
+	["name"] = 'WEAPON_PETROLCAN',
+	["label"] = 'Gas Can',
+	},
+	[-1357824103] = {
+	["name"] = 'WEAPON_ADVANCEDRIFLE',
+	["label"] = 'Advanced Rifle',
+	},
+	[736523883] = {
+	["name"] = 'WEAPON_SMG',
+	["label"] = 'SMG',
+	},
+	[205991906] = {
+	["name"] = 'WEAPON_HEAVYSNIPER',
+	["label"] = 'Heavy Sniper',
+	},
+	[-1312131151] = {
+	["name"] = 'WEAPON_RPG',
+	["label"] = 'RPG',
+	},
+	[-771403250] = {
+	["name"] = 'WEAPON_HEAVYPISTOL',
+	["label"] = 'Heavy Pistol',
+	},
+	[-879347409] = {
+	["name"] = 'WEAPON_REVOLVER_MK2',
+	["label"] = 'Revolver MK2',
+	},
+	[-494615257] = {
+	["name"] = 'WEAPON_ASSAULTSHOTGUN',
+	["label"] = 'Assault Shotgun',
+	},
+	[-947031628] = {
+	["name"] = 'WEAPON_HEAVYRIFLE',
+	["label"] = 'Heavy Rifle',
+	},
+	[-1420407917] = {
+	["name"] = 'WEAPON_PROXMINE',
+	["label"] = 'Proximity Mine',
+	},
+	[-619010992] = {
+	["name"] = 'WEAPON_MACHINEPISTOL',
+	["label"] = 'Machine Pistol',
+	},
+	[-1746263880] = {
+	["name"] = 'WEAPON_DOUBLEACTION',
+	["label"] = 'Double Action Revolver',
+	},
+	[125959754] = {
+	["name"] = 'WEAPON_COMPACTLAUNCHER',
+	["label"] = 'Compact Grenade Launcher',
+	},
+	[2132975508] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE',
+	["label"] = 'Bullpup Rifle',
+	},
+	[-86904375] = {
+	["name"] = 'WEAPON_CARBINERIFLE_MK2',
+	["label"] = 'Carbine Rifle MK2',
+	},
+	[453432689] = {
+	["name"] = 'WEAPON_PISTOL',
+	["label"] = 'Pistol',
+	},
+	[-1074790547] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE',
+	["label"] = 'Assault Rifle',
+	},
+	[1627465347] = {
+	["name"] = 'WEAPON_GUSENBERG',
+	["label"] = 'Gusenberg',
+	},
+	[911657153] = {
+	["name"] = 'WEAPON_STUNGUN',
+	["label"] = 'Tazer',
+	},
+	[-1121678507] = {
+	["name"] = 'WEAPON_MINISMG',
+	["label"] = 'Mini SMG',
+	},
+	[171789620] = {
+	["name"] = 'WEAPON_COMBATPDW',
+	["label"] = 'Combat PDW',
+	},
+	[1141786504] = {
+	["name"] = 'WEAPON_GOLFCLUB',
+	["label"] = 'Golf Club',
+	},
+	[1834241177] = {
+	["name"] = 'WEAPON_RAILGUN',
+	["label"] = 'Railgun',
+	},
+	[1119849093] = {
+	["name"] = 'WEAPON_MINIGUN',
+	["label"] = 'Minigun',
+	},
+	[961495388] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE_MK2',
+	["label"] = 'Assault Rifle MK2',
+	},
+	[406929569] = {
+	["name"] = 'WEAPON_FERTILIZERCAN',
+	["label"] = 'Fertilizer Can',
+	},
+	[1233104067] = {
+	["name"] = 'WEAPON_FLARE',
+	["label"] = 'Flare',
+	},
+	[419712736] = {
+	["name"] = 'WEAPON_WRENCH',
+	["label"] = 'Wrench',
+	},
+	[-2009644972] = {
+	["name"] = 'WEAPON_SNSPISTOL_MK2',
+	["label"] = 'SNS Pistol MK2',
+	},
+	[-102973651] = {
+	["name"] = 'WEAPON_HATCHET',
+	["label"] = 'Hatchet',
+	},
+	[-2066285827] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE_MK2',
+	["label"] = 'Bullpup Rifle MK2',
+	},
+	[-1169823560] = {
+	["name"] = 'WEAPON_PIPEBOMB',
+	["label"] = 'Pipe Bomb',
+	},
+	[1703483498] = {
+	["name"] = 'WEAPON_CANDYCANE',
+	["label"] = 'Candy Cane',
+	},
+	[-598887786] = {
+	["name"] = 'WEAPON_MARKSMANPISTOL',
+	["label"] = 'Marksman Pistol',
+	},
+	[350597077] = {
+	["name"] = 'WEAPON_TECPISTOL',
+	["label"] = 'Tactical SMG',
+	},
+	[-1786099057] = {
+	["name"] = 'WEAPON_BAT',
+	["label"] = 'Bat',
+	},
+	[2138347493] = {
+	["name"] = 'WEAPON_FIREWORK',
+	["label"] = 'Firework Launcher',
+	},
+	[-1658906650] = {
+	["name"] = 'WEAPON_MILITARYRIFLE',
+	["label"] = 'Military Rifle',
+	},
+	[-656458692] = {
+	["name"] = 'WEAPON_KNUCKLE',
+	["label"] = 'Knuckle Dusters',
+	},
+	[126349499] = {
+	["name"] = 'WEAPON_SNOWBALL',
+	["label"] = 'Snow Ball',
+	},
+	[177293209] = {
+	["name"] = 'WEAPON_HEAVYSNIPER_MK2',
+	["label"] = 'Heavy Sniper MK2',
+	},
+	[-774507221] = {
+	["name"] = 'WEAPON_TACTICALRIFLE',
+	["label"] = 'Tactical Rifle',
+	},
+	[101631238] = {
+	["name"] = 'WEAPON_FIREEXTINGUISHER',
+	["label"] = 'Fire Extinguisher',
+	},
+	[-102323637] = {
+	["name"] = 'WEAPON_BOTTLE',
+	["label"] = 'Bottle',
+	},
+	[741814745] = {
+	["name"] = 'WEAPON_STICKYBOMB',
+	["label"] = 'Sticky Bomb',
+	},
+	[1672152130] = {
+	["name"] = 'WEAPON_HOMINGLAUNCHER',
+	["label"] = 'Homing Launcher',
+	},
+	[-1810795771] = {
+	["name"] = 'WEAPON_POOLCUE',
+	["label"] = 'Pool Cue',
+	},
+}
+
+
+return Weapon

--- a/2.47.0/client.lua
+++ b/2.47.0/client.lua
@@ -1,0 +1,2012 @@
+if not lib then return end
+
+require 'modules.bridge.client'
+require 'modules.interface.client'
+
+local Utils = require 'modules.utils.client'
+local Weapon = require 'modules.weapon.client'
+local currentWeapon
+
+--Holgers Anpassungen
+HotbarundWeaponWheel = false
+EnableWeaponWheel = true
+Waffencache = {}
+--Holgers Anpassungen bis hier
+
+exports('getCurrentWeapon', function()
+	return currentWeapon
+end)
+
+RegisterNetEvent('ox_inventory:disarm', function(noAnim)
+	currentWeapon = Weapon.Disarm(currentWeapon, noAnim)
+end)
+
+RegisterNetEvent('ox_inventory:clearWeapons', function()
+	Weapon.ClearAll(currentWeapon)
+end)
+
+local StashTarget
+
+exports('setStashTarget', function(id, owner)
+	StashTarget = id and {id=id, owner=owner}
+end)
+
+---@type boolean | number
+local invBusy = true
+
+---@type boolean?
+local invOpen = false
+local plyState = LocalPlayer.state
+local IsPedCuffed = IsPedCuffed
+local playerPed = cache.ped
+
+lib.onCache('ped', function(ped)
+	playerPed = ped
+	Utils.WeaponWheel()
+end)
+
+plyState:set('invBusy', true, true)
+plyState:set('invHotkeys', false, false)
+plyState:set('canUseWeapons', false, false)
+
+local function canOpenInventory()
+    if not PlayerData.loaded then
+        return shared.info('cannot open inventory', '(player inventory has not loaded)')
+    end
+
+    if IsPauseMenuActive() then return end
+
+    if invBusy or invOpen == nil or (currentWeapon?.timer or 0) > 0 then
+        return shared.info('cannot open inventory', '(is busy)')
+    end
+
+    if PlayerData.dead or IsPedFatallyInjured(playerPed) then
+        return shared.info('cannot open inventory', '(fatal injury)')
+    end
+
+    if PlayerData.cuffed or IsPedCuffed(playerPed) then
+        return shared.info('cannot open inventory', '(cuffed)')
+    end
+
+    return true
+end
+
+---@param ped number
+---@return boolean
+local function canOpenTarget(ped)
+	return IsPedFatallyInjured(ped)
+	or IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3)
+	or IsPedCuffed(ped)
+	or IsEntityPlayingAnim(ped, 'mp_arresting', 'idle', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_enter', 3)
+	or IsEntityPlayingAnim(ped, 'random@mugging3', 'handsup_standing_base', 3)
+end
+
+---@class OpenInventory
+---@field id string | integer
+---@field label string
+---@field type string
+---@field slots integer
+---@field weight integer
+---@field maxWeight integer
+---@field coords? vector3
+---@field distance? integer
+---@field instance? string | number
+---@field [string] unknown
+local defaultInventory = {
+	type = 'newdrop',
+	slots = shared.dropslots,
+	weight = 0,
+	maxWeight = shared.dropweight,
+	items = {}
+}
+
+local currentInventory = defaultInventory
+
+local function closeTrunk()
+	if currentInventory.type == 'trunk' then
+		local coords = GetEntityCoords(playerPed, true)
+		---@todo animation for vans?
+		Utils.PlayAnimAdvanced(0, 'anim@heists@fleeca_bank@scope_out@return_case', 'trevor_action', coords.x, coords.y, coords.z, 0.0, 0.0, GetEntityHeading(playerPed), 2.0, 2.0, 1000, 49, 0.25)
+
+		CreateThread(function()
+			local entity = currentInventory.entity
+			local door = currentInventory.door
+			Wait(900)
+
+			if type(door) == 'table' then
+				for i = 1, #door do
+					SetVehicleDoorShut(entity, door[i], false)
+				end
+			else
+				SetVehicleDoorShut(entity, door, false)
+			end
+		end)
+	end
+end
+
+local CraftingBenches = require 'modules.crafting.client'
+local Vehicles = lib.load('data.vehicles')
+local Inventory = require 'modules.inventory.client'
+
+---@param inv string?
+---@param data any?
+---@return boolean?
+function client.openInventory(inv, data)
+	if invOpen then
+		if not inv and currentInventory.type == 'newdrop' then
+			return client.closeInventory()
+		end
+
+		if IsNuiFocused() then
+			if inv == 'container' and currentInventory.id == PlayerData.inventory[data].metadata.container then
+				return client.closeInventory()
+			end
+
+			if currentInventory.type == 'drop' and (not data or currentInventory.id == (type(data) == 'table' and data.id or data)) then
+				return client.closeInventory()
+			end
+
+			if inv ~= 'drop' and inv ~= 'container' then
+				if (data?.id or data) == currentInventory.id then
+					-- Triggering exports.ox_inventory:openInventory('stash', 'mystash') twice in rapid succession is weird behaviour
+					return warn(("script tried to open inventory, but it is already open\n%s"):format(Citizen.InvokeNative(`FORMAT_STACK_TRACE` & 0xFFFFFFFF, nil, 0, Citizen.ResultAsString())))
+				else
+					return client.closeInventory()
+				end
+			end
+		end
+	elseif IsNuiFocused() then
+		-- If triggering from another nui, may need to wait for focus to end.
+		Wait(100)
+
+        -- People still complain about this being an "error" and ask "how fix" despite being a warning
+        -- for people with above room-temperature iqs to look into resource conflicts on their own.
+		-- if IsNuiFocused() then
+		-- 	warn('other scripts have nui focus and may cause issues (e.g. disable focus, prevent input, overlap inventory window)')
+		-- end
+	end
+
+	if inv == 'dumpster' and cache.vehicle then
+		return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+	end
+
+	if not canOpenInventory() then
+        return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+    end
+
+    local left, right, accessError
+
+    if inv == 'player' and data ~= cache.serverId then
+        local targetId, targetPed, serverId
+
+        if not data then
+            targetId, targetPed = Utils.GetClosestPlayer()
+            serverId = targetId and GetPlayerServerId(targetId)
+            data = serverId
+        else
+            serverId = type(data) == 'table' and data.id or data
+            targetId = serverId and GetPlayerFromServerId(serverId)
+            targetPed = targetId and GetPlayerPed(targetId)
+        end
+
+        if serverId == cache.serverId then return end
+
+        local targetCoords = targetPed and GetEntityCoords(targetPed)
+
+        if not targetCoords or #(targetCoords - GetEntityCoords(playerPed)) > 1.8 or (not client.hasGroup(shared.police) and not Player(serverId).state.canSteal) then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+    end
+
+    if inv == 'shop' and invOpen == false then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
+    elseif inv == 'crafting' then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+
+        if left then
+            right = CraftingBenches[data.id]
+
+            if not right?.items then return end
+
+            local coords, distance
+
+            if not right.zones and not right.points then
+                coords = GetEntityCoords(cache.ped)
+                distance = 2
+            else
+                coords = shared.target and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+                distance = coords and shared.target and right.zones[data.index].distance or 2
+            end
+
+            right = {
+                type = 'crafting',
+                id = data.id,
+                label = right.label or locale('crafting_bench'),
+                index = data.index,
+                slots = right.slots,
+                items = right.items,
+                coords = coords,
+                distance = distance
+            }
+        end
+    elseif invOpen ~= nil then
+        if inv == 'policeevidence' then
+            if not data then
+                local input = lib.inputDialog(locale('police_evidence'), {
+                    { label = locale('locker_number'), type = 'number', required = true, icon = 'calculator' }
+                }) --[[@as number[]? ]]
+
+                if not input then return end
+
+                data = input[1]
+            end
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+    end
+
+    if accessError then
+        return lib.notify({ id = accessError, type = 'error', description = locale(accessError) })
+    end
+
+    -- Stash does not exist
+    if not left then
+        if left == false then return false end
+
+        if invOpen == false then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+
+        if invOpen then return client.closeInventory() end
+    end
+
+
+    if not cache.vehicle then
+        if inv == 'player' then
+            Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+        elseif inv ~= 'trunk' then
+            Utils.PlayAnim(0, 'pickup_object', 'putdown_low', 5.0, 1.5, 1000, 48, 0.0, 0, 0, 0)
+        end
+    end
+
+    plyState.invOpen = true
+
+    SetInterval(client.interval, 100)
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+    closeTrunk()
+
+    if client.screenblur then Utils.blurIn() end
+
+    currentInventory = right or defaultInventory
+    left.items = PlayerData.inventory
+    left.groups = PlayerData.groups
+
+    SendNUIMessage({
+        action = 'setupInventory',
+        data = {
+            leftInventory = left,
+            rightInventory = currentInventory
+        }
+    })
+
+    if inv and not currentInventory.coords and inv ~= 'container' and inv ~= 'glovebox' then
+        currentInventory.coords = GetEntityCoords(playerPed)
+    end
+
+    if inv == 'trunk' then
+        SetTimeout(200, function()
+            ---@todo animation for vans?
+            Utils.PlayAnim(0, 'anim@heists@prison_heiststation@cop_reactions', 'cop_b_idle', 3.0, 3.0, -1, 49, 0.0, 0, 0, 0)
+
+            local entity = data.entity or NetworkGetEntityFromNetworkId(data.netid)
+            currentInventory.entity = entity
+            currentInventory.door = data.door
+
+            if not currentInventory.door then
+                local vehicleHash = GetEntityModel(entity)
+                local vehicleClass = GetVehicleClass(entity)
+                currentInventory.door = vehicleClass == 12 and { 2, 3 } or Vehicles.Storage[vehicleHash] and 4 or 5
+            end
+
+            while currentInventory.entity == entity and invOpen and DoesEntityExist(entity) and Inventory.CanAccessTrunk(entity) do
+                Wait(100)
+            end
+
+            if invOpen then client.closeInventory() end
+        end)
+    end
+
+    return true
+end
+
+RegisterNetEvent('ox_inventory:openInventory', client.openInventory)
+exports('openInventory', client.openInventory)
+
+RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+local Animations = lib.load('data.animations')
+local Items = require 'modules.items.client'
+local usingItem = false
+
+---@param data { name: string, label: string, count: number, slot: number, metadata: table<string, any>, weight: number }
+lib.callback.register('ox_inventory:usingItem', function(data, noAnim)
+	local item = Items[data.name]
+
+	if item and usingItem then
+		if not item.client then return true end
+		---@cast item +OxClientProps
+		item = item.client
+
+		if type(item.anim) == 'string' then
+			item.anim = Animations.anim[item.anim]
+		end
+
+		if item.prop then
+			if item.prop[1] then
+				for i = 1, #item.prop do
+					if type(item.prop) == 'string' then
+						item.prop = Animations.prop[item.prop[i]]
+					end
+				end
+			elseif type(item.prop) == 'string' then
+				item.prop = Animations.prop[item.prop]
+			end
+		end
+
+		if not item.disable then
+			item.disable = { combat = true }
+		elseif item.disable.combat == nil then
+			-- Backwards compatibility; you probably don't want people shooting while eating and bandaging anyway
+			item.disable.combat = true
+		end
+
+		local success = (not item.usetime or noAnim or lib.progressBar({
+			duration = item.usetime,
+			label = item.label or locale('using', data.metadata.label or data.label),
+			useWhileDead = item.useWhileDead,
+			canCancel = item.cancel,
+			disable = item.disable,
+			anim = item.anim or item.scenario,
+			prop = item.prop --[[@as ProgressProps]]
+		})) and not PlayerData.dead
+
+		if success then
+			if item.notification then
+				lib.notify({ description = item.notification })
+			end
+
+			if item.status then
+				if client.setPlayerStatus then
+					client.setPlayerStatus(item.status)
+				end
+			end
+
+			return true
+		end
+	end
+end)
+
+local function canUseItem(isAmmo)
+	local ped = cache.ped
+
+	return not usingItem
+    and (not isAmmo or currentWeapon)
+	and PlayerData.loaded
+	and not PlayerData.dead
+	and not invBusy
+	and not lib.progressActive()
+	and not IsPedRagdoll(ped)
+	and not IsPedFalling(ped)
+    and not IsPedShooting(playerPed)
+end
+
+---@param data table
+---@param cb fun(response: SlotWithItem | false)?
+---@param noAnim? boolean
+local function useItem(data, cb, noAnim)
+	local slotData, result = PlayerData.inventory[data.slot]
+
+	if not slotData or not canUseItem(data.ammo and true) then
+        if currentWeapon then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        return
+    end
+
+	if currentWeapon and currentWeapon.timer ~= 0 then
+        if not currentWeapon.timer or currentWeapon.timer - GetGameTimer() > 100 then return end
+
+        DisablePlayerFiring(cache.playerId, true)
+    end
+
+    if invOpen and data.close then client.closeInventory() end
+
+    usingItem = true
+    ---@type boolean?
+    result = lib.callback.await('ox_inventory:useItem', 200, data.name, data.slot, slotData.metadata, noAnim)
+
+	if result and cb then
+		local success, response = pcall(cb, result and slotData)
+
+		if not success and response then
+			warn(('^1An error occurred while calling item "%s" callback!\n^1SCRIPT ERROR: %s^0'):format(slotData.name, response))
+		end
+	end
+
+    if result then
+        TriggerEvent('ox_inventory:usedItem', slotData.name, slotData.slot, next(slotData.metadata) and slotData.metadata)
+    end
+
+	Wait(500)
+    usingItem = false
+end
+
+AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+end)
+
+AddEventHandler('ox_inventory:item', useItem)
+exports('useItem', useItem)
+
+---@param slot number
+---@return boolean?
+local function useSlot(slot, noAnim, dings) --dings added by Holger
+	local item = PlayerData.inventory[slot]
+	if not item then return end
+
+	local data = Items[item.name]
+	if not data then return end
+
+	if canUseItem(data.ammo and true) then
+		if data.component and not currentWeapon then
+			return lib.notify({ id = 'weapon_hand_required', type = 'error', description = locale('weapon_hand_required') })
+		end
+
+		local durability = item.metadata.durability --[[@as number?]]
+		local consume = data.consume --[[@as number?]]
+		local label = item.metadata.label or item.label --[[@as string]]
+
+		-- Naive durability check to get an early exit
+		-- People often don't call the 'useItem' export and then complain about "broken" items being usable
+		-- This won't work with degradation since we need access to os.time on the server
+		if durability and durability <= 100 and consume then
+			if durability <= 0 then
+				return lib.notify({ type = 'error', description = locale('no_durability', label) })
+			elseif consume ~= 0 and consume < 1 and durability < consume * 100 then
+				return lib.notify({ type = 'error', description = locale('not_enough_durability', label) })
+			end
+		end
+
+		data.slot = slot
+
+		if item.metadata.container then
+			return client.openInventory('container', item.slot)
+		elseif data.client then
+			if invOpen and data.close then client.closeInventory() end
+
+			if data.export then
+				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
+				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			end
+		end
+
+		if data.effect then
+			data:effect({name = item.name, slot = item.slot, metadata = item.metadata})
+		elseif data.weapon then
+			if not plyState.canUseWeapons then return end
+			if EnableWeaponWheel then -- if by Holger
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+
+					if dings then -- if by Holger
+						currentWeapon =  Weapon.Disarm(currentWeapon,false,true)
+					else					
+						currentWeapon =  Weapon.Disarm(currentWeapon)
+					end
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			else
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+					
+					currentWeapon =  Weapon.Disarm(currentWeapon)
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			end
+		elseif currentWeapon then
+			if data.ammo then
+				if Utils.Waffensyncaus or currentWeapon.metadata.durability <= 0 then return end ----Holger replaced : EnableWeaponWheel to Utils.Waffensyncaus
+
+				local clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+				local currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+				local _, maxAmmo = GetMaxAmmo(playerPed, currentWeapon.hash)
+
+				if maxAmmo < clipSize then clipSize = maxAmmo end
+
+				if currentAmmo == clipSize then return end
+
+				useItem(data, function(resp)
+					if not resp or resp.name ~= currentWeapon?.ammo then return end
+
+					if currentWeapon.metadata.specialAmmo ~= resp.metadata.type and type(currentWeapon.metadata.specialAmmo) == 'string' then
+						local clipComponentKey = ('%s_CLIP'):format(Items[currentWeapon.name].model:gsub('WEAPON_', 'COMPONENT_'))
+						local specialClip = ('%s_%s'):format(clipComponentKey, (resp.metadata.type or currentWeapon.metadata.specialAmmo):upper())
+
+						if type(resp.metadata.type) == 'string' then
+							if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+								if not DoesWeaponTakeWeaponComponent(currentWeapon.hash, specialClip) then
+									warn('cannot use clip with this weapon')
+									return
+								end
+
+								local defaultClip = ('%s_01'):format(clipComponentKey)
+
+								if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, defaultClip) then
+									warn('cannot use clip with currently equipped clip')
+									return
+								end
+
+								if currentAmmo > 0 then
+									warn('cannot mix special ammo with base ammo')
+									return
+								end
+
+								currentWeapon.metadata.specialAmmo = resp.metadata.type
+
+								GiveWeaponComponentToPed(playerPed, currentWeapon.hash, specialClip)
+							end
+						elseif HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+							if currentAmmo > 0 then
+								warn('cannot mix special ammo with base ammo')
+								return
+							end
+
+							currentWeapon.metadata.specialAmmo = nil
+
+							RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, specialClip)
+						end
+					end
+
+					if maxAmmo > clipSize then
+						clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+					end
+
+					currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+					local missingAmmo = clipSize - currentAmmo
+					local addAmmo = resp.count > missingAmmo and missingAmmo or resp.count
+					local newAmmo = currentAmmo + addAmmo
+
+					if newAmmo == currentAmmo then return end
+
+                    AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
+
+					if cache.vehicle then
+						if cache.seat > -1 or IsVehicleStopped(cache.vehicle) then
+							TaskReloadWeapon(playerPed, true)
+                        else
+                            -- This is a hacky solution for forcing ammo to properly load into the
+                            -- weapon clip while driving; without it, ammo will be added but won't
+                            -- load until the player stops doing anything. i.e. if you keep shooting,
+                            -- the weapon will not reload until the clip empties.
+                            -- And yes - for some reason RefillAmmoInstantly needs to run in a loop.
+                            lib.waitFor(function()
+                                RefillAmmoInstantly(playerPed)
+
+                                local _, ammo = GetAmmoInClip(playerPed, currentWeapon.hash)
+                                return ammo == newAmmo or nil
+                            end)
+                        end
+					else
+						Wait(100)
+						MakePedReload(playerPed)
+
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
+					end
+
+					lib.callback.await('ox_inventory:updateWeapon', false, 'load', newAmmo, false, currentWeapon.metadata.specialAmmo)
+				end)
+			elseif data.component then
+				local components = data.client.component
+
+                if not components then return end
+
+				local componentType = data.type
+				local weaponComponents = PlayerData.inventory[currentWeapon.slot].metadata.components
+
+				-- Checks if the weapon already has the same component type attached
+				for componentIndex = 1, #weaponComponents do
+					if componentType == Items[weaponComponents[componentIndex]].type then
+						return lib.notify({ id = 'component_slot_occupied', type = 'error', description = locale('component_slot_occupied', componentType) })
+					end
+				end
+
+				for i = 1, #components do
+					local component = components[i]
+
+					if DoesWeaponTakeWeaponComponent(currentWeapon.hash, component) then
+						if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+							lib.notify({ id = 'component_has', type = 'error', description = locale('component_has', label) })
+						else
+							useItem(data, function(data)
+								if data then
+									local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', tostring(data.slot), currentWeapon.slot)
+
+									if success then
+										GiveWeaponComponentToPed(playerPed, currentWeapon.hash, component)
+										TriggerEvent('ox_inventory:updateWeaponComponent', 'added', component, data.name)
+									end
+								end
+							end)
+						end
+						return
+					end
+				end
+				lib.notify({ id = 'component_invalid', type = 'error', description = locale('component_invalid', label) })
+			elseif data.allowArmed then
+				useItem(data)
+            else
+                return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+			end
+		elseif not data.ammo and not data.component then
+			useItem(data)
+		end
+    end
+end
+exports('useSlot', useSlot)
+
+---@param id number
+---@param slot number
+local function useButton(id, slot)
+	if PlayerData.loaded and not invBusy and not lib.progressActive() then
+		local item = PlayerData.inventory[slot]
+		if not item then return end
+
+		local data = Items[item.name]
+		local buttons = data?.buttons
+
+		if buttons and buttons[id]?.action then
+			buttons[id].action(slot)
+		end
+	end
+end
+
+local function openNearbyInventory() client.openInventory('player') end
+
+exports('openNearbyInventory', openNearbyInventory)
+
+local currentInstance
+local playerCoords
+local Shops = require 'modules.shops.client'
+
+---@todo remove or replace when the bridge module gets restructured
+function OnPlayerData(key, val)
+	if key ~= 'groups' and key ~= 'ped' and key ~= 'dead' then return end
+
+	if key == 'groups' then
+		Inventory.Stashes()
+		Inventory.Evidence()
+		Shops.refreshShops()
+	elseif key == 'dead' and val then
+		currentWeapon = Weapon.Disarm(currentWeapon)
+		client.closeInventory()
+	end
+
+	Utils.WeaponWheel()
+end
+
+-- People consistently ignore errors when one of the "modules" failed to load
+if not Utils or not Weapon or not Items or not Inventory then return end
+
+local invHotkeys = false
+
+---@type function?
+local function registerCommands()
+	if client.enablestealcommand then
+		RegisterCommand('steal', openNearbyInventory, false)
+	end
+
+	local function openGlovebox(vehicle)
+		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end
+
+		if IsEntityDead(vehicle) then return end
+
+		local vehicleHash = GetEntityModel(vehicle)
+		local vehicleClass = GetVehicleClass(vehicle)
+		local checkVehicle = Vehicles.Storage[vehicleHash]
+
+		-- No storage or no glovebox
+		if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
+
+		local isOpen = client.openInventory('glovebox', { netid = NetworkGetNetworkIdFromEntity(vehicle) })
+
+		if isOpen then
+			currentInventory.entity = vehicle
+		end
+	end
+
+	local primary = lib.addKeybind({
+		name = 'inv',
+		description = locale('open_player_inventory'),
+		defaultKey = client.keys[1],
+		onPressed = function()
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local closest = lib.points.getClosestPoint()
+
+			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
+				if closest.inv == 'crafting' then
+					return client.openInventory('crafting', { id = closest.id, index = closest.index })
+				elseif closest.inv ~= 'license' and closest.inv ~= 'policeevidence' then
+					return client.openInventory(closest.inv or 'drop', { id = closest.invId, type = closest.type })
+				end
+			end
+
+			return client.openInventory()
+		end
+	})
+
+	lib.addKeybind({
+		name = 'inv2',
+		description = locale('open_secondary_inventory'),
+		defaultKey = client.keys[2],
+		onPressed = function(self)
+            if primary:getCurrentKey() == self:getCurrentKey() then
+                return warn(("secondary inventory keybind '%s' disabled (keybind cannot match primary inventory keybind)"):format(self:getCurrentKey()))
+            end
+
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if invBusy or not canOpenInventory() then
+				return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+			end
+
+			if StashTarget then
+				return client.openInventory('stash', StashTarget)
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local entity, entityType = Utils.Raycast(2|16)
+
+			if not entity then return end
+
+			if not shared.target and entityType == 3 then
+				local model = GetEntityModel(entity)
+
+				if Inventory.Dumpsters:includes(model) then
+					return Inventory.OpenDumpster(entity)
+				end
+			end
+
+			if entityType ~= 2 then return end
+
+			Inventory.OpenTrunk(entity)
+		end
+	})
+
+	lib.addKeybind({
+		name = 'reloadweapon',
+		description = locale('reload_weapon'),
+		defaultKey = 'r',
+		onPressed = function(self)
+			if not currentWeapon or Utils.Waffensyncaus or not canUseItem(true) then return end ---Holger changed EnableWeaponWheel to Utils.Waffensyncaus
+
+			if currentWeapon.ammo then
+				if currentWeapon.metadata.durability > 0 then
+					local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+					if slotId then
+						useSlot(slotId)
+					end
+				else
+					lib.notify({ id = 'no_durability', type = 'error', description = locale('no_durability', currentWeapon.label) })
+				end
+			end
+		end
+	})
+
+	lib.addKeybind({
+		name = 'hotbar',
+		description = locale('disable_hotbar'),
+		defaultKey = client.keys[3],
+		onPressed = function()
+			if (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() or lib.progressActive() then return end --Holger added: and not HotbarundWeaponWheel
+			SendNUIMessage({ action = 'toggleHotbar' })
+		end
+	})
+
+	for i = 1, 5 do
+		lib.addKeybind({
+			name = ('hotkey%s'):format(i),
+			description = locale('use_hotbar', i),
+			defaultKey = tostring(i),
+			onPressed = function()
+				if invOpen or (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() then return end --Holger added: and not HotbarundWeaponWheel
+				useSlot(i)
+			end
+		})
+	end
+
+	registerCommands = nil
+end
+
+function client.closeInventory()
+	if not client.interval then return end
+
+	if invOpen then
+		invOpen = nil
+		SetNuiFocus(false, false)
+		SetNuiFocusKeepInput(false)
+		Utils.blurOut()
+		closeTrunk()
+		SendNUIMessage({ action = 'closeInventory' })
+		SetInterval(client.interval, 200)
+		Wait(200)
+
+		if invOpen ~= nil then return end
+
+		TriggerServerEvent('ox_inventory:closeInventory')
+
+		currentInventory = defaultInventory
+		plyState.invOpen = false
+		defaultInventory.coords = nil
+	end
+end
+
+RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
+exports('closeInventory', client.closeInventory)
+
+---@param data updateSlot[]
+---@param weight number
+local function updateInventory(data, weight)
+	local changes = {}
+    ---@type table<string, number>
+	local itemCount = {}
+
+	for i = 1, #data do
+		local v = data[i]
+
+		if not v.inventory or v.inventory == cache.serverId then
+			v.inventory = 'player'
+			local item = v.item
+
+			if currentWeapon?.slot == item?.slot then
+                if item.metadata then
+				    currentWeapon.metadata = item.metadata
+				    TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
+                else
+                    currentWeapon = Weapon.Disarm(currentWeapon, true)
+                end
+			end
+
+			local curItem = PlayerData.inventory[item.slot]
+
+			if curItem and curItem.name then  -- if changed by Holger
+				if itemCount[curItem.name] == nil then
+					itemCount[curItem.name] = {}
+				end
+				itemCount[curItem.name].count = (itemCount[curItem.name].count or 0) - curItem.count
+				itemCount[curItem.name].slot = item.slot
+			end
+
+			if item.count then	-- if changed by Holger
+				if itemCount[item.name] == nil then
+					itemCount[item.name] = {}
+				end
+				itemCount[item.name].count = (itemCount[item.name].count or 0) + item.count
+				itemCount[item.name].slot = item.slot
+			end
+
+			changes[item.slot] = item.count and item or false
+			if not item.count then item.name = nil end
+			PlayerData.inventory[item.slot] = item.name and item or nil
+		end
+	end
+
+	SendNUIMessage({ action = 'refreshSlots', data = { items = data, itemCount = itemCount} })
+
+    if weight ~= PlayerData.weight then client.setPlayerData('weight', weight) end
+
+	for itemName, dings in pairs(itemCount) do --changed count to dings	Holger
+		local item = Items(itemName)
+
+        if item then
+            item.count += dings.count --added dings.	Holger
+
+			------------Holgers Anpassungen
+			if string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN"  and item.count  >0 and not HasPedGotWeapon(cache.ped,item.name,false) then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash] = {}
+				Waffencache[hash].name = item.name
+				Waffencache[hash].slot = dings.slot
+				Waffencache[hash].hash = hash
+				
+				RemoveWeaponFromPed(cache.ped,item.name)
+				GiveWeaponToPed(cache.ped,item.name,1,false,false) 
+			elseif string.sub(item.name,1,7) =="WEAPON_" and item.count  == 0 then
+				local loeschdas
+				for k,v in pairs(Waffencache) do
+					if v.name ==item.name then
+						loeschdas = k
+					end
+				end
+				Waffencache[loeschdas] = nil
+				if currentWeapon and currentWeapon.name == item.name then
+					currentWeapon = Weapon.Disarm(currentWeapon, false,"lurch")
+				else
+					RemoveWeaponFromPed(cache.ped,item.name)
+				end 
+			end
+
+			-----Holgers Anpassungen ende
+
+            TriggerEvent('ox_inventory:itemCount', item.name, item.count)
+
+            if dings.count < 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:removeInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.remove then
+                    item.client.remove(item.count)
+                end
+            elseif dings.count > 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:addInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.add then
+                    item.client.add(item.count)
+                end
+            end
+        end
+	end
+
+	client.setPlayerData('inventory', PlayerData.inventory)
+	TriggerEvent('ox_inventory:updateInventory', changes)
+end
+
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
+	if source ~= '' and next(items) then updateInventory(items, weights) end
+end)
+
+RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
+	if source == '' then return end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	lib.notify({ description = locale('items_returned') })
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for _, slotData in pairs(data[1]) do
+		num += 1
+		items[num] = { item = slotData, inventory = cache.serverId }
+	end
+
+	updateInventory(items, data[3])
+end)
+
+RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
+	if source == '' then return end
+	if message then lib.notify({ description = locale('items_confiscated') }) end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for slot in pairs(PlayerData.inventory) do
+		num += 1
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
+	end
+
+	updateInventory(items, 0)
+end)
+
+
+---@param point CPoint
+local function nearbyDrop(point)
+	if not point.instance or point.instance == currentInstance then
+        DrawMarker(client.dropmarker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, client.dropmarker.scale[1], client.dropmarker.scale[2], client.dropmarker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        client.dropmarker.colour[1], client.dropmarker.colour[2], client.dropmarker.colour[3], 222, false, false, 0, true, false, false, false)
+    end
+end
+
+---@param point CPoint
+local function onEnterDrop(point)
+	if not point.instance or point.instance == currentInstance and not point.entity then
+		local model = point.model or client.dropmodel
+
+        -- Prevent breaking inventory on invalid point.model instead use default client.dropmodel
+        if not IsModelValid(model) and not IsModelInCdimage(model) then
+            model = client.dropmodel
+        end
+		lib.requestModel(model)
+
+		local entity = CreateObject(model, point.coords.x, point.coords.y, point.coords.z, false, true, true)
+
+		SetModelAsNoLongerNeeded(model)
+		PlaceObjectOnGroundProperly(entity)
+		FreezeEntityPosition(entity, true)
+		SetEntityCollision(entity, false, true)
+
+		point.entity = entity
+	end
+end
+
+local function onExitDrop(point)
+	local entity = point.entity
+
+	if entity then
+		Utils.DeleteEntity(entity)
+		point.entity = nil
+	end
+end
+
+local function createDrop(dropId, data)
+	local point = lib.points.new({
+		coords = data.coords,
+		distance = 16,
+		invId = dropId,
+		instance = data.instance,
+		model = data.model
+	})
+
+	if point.model or client.dropprops then
+		point.distance = 30
+		point.onEnter = onEnterDrop
+		point.onExit = onExitDrop
+	else
+		point.nearby = nearbyDrop
+	end
+
+	client.drops[dropId] = point
+end
+
+RegisterNetEvent('ox_inventory:createDrop', function(dropId, data, owner, slot)
+	if client.drops then
+		createDrop(dropId, data)
+	end
+
+	if owner == cache.serverId then
+		if currentWeapon?.slot == slot then
+			currentWeapon = Weapon.Disarm(currentWeapon)
+		end
+
+		if invOpen and #(GetEntityCoords(playerPed) - data.coords) <= 1 then
+			if not cache.vehicle then
+				client.openInventory('drop', dropId)
+			else
+				SendNUIMessage({
+					action = 'setupInventory',
+					data = { rightInventory = currentInventory }
+				})
+			end
+		end
+	end
+end)
+
+RegisterNetEvent('ox_inventory:removeDrop', function(dropId)
+	if client.drops then
+		local point = client.drops[dropId]
+
+		if point then
+			client.drops[dropId] = nil
+			point:remove()
+
+			if point.entity then Utils.DeleteEntity(point.entity) end
+		end
+	end
+end)
+
+---@type function?
+local function setStateBagHandler(stateId)
+	AddStateBagChangeHandler('invOpen', stateId, function(_, _, value)
+		invOpen = value
+	end)
+
+	AddStateBagChangeHandler('invBusy', stateId, function(_, _, value)
+		invBusy = value
+	end)
+
+    AddStateBagChangeHandler('canUseWeapons', stateId, function(_, _, value)
+        if not value and currentWeapon then
+            currentWeapon = Weapon.Disarm(currentWeapon)
+        end
+    end)
+
+	AddStateBagChangeHandler('instance', stateId, function(_, _, value)
+		currentInstance = value
+
+		if client.drops then
+			-- Iterate over known drops and remove any points in a different instance (ignoring no instance)
+			for dropId, point in pairs(client.drops) do
+				if point.instance then
+					if point.instance ~= value then
+						if point.entity then
+							Utils.DeleteEntity(point.entity)
+							point.entity = nil
+						end
+
+						point:remove()
+					else
+						-- Recreate the drop using data from the old point
+						createDrop(dropId, point)
+					end
+				end
+			end
+		end
+	end)
+
+	AddStateBagChangeHandler('dead', stateId, function(_, _, value)
+		Utils.WeaponWheel()
+		PlayerData.dead = value
+	end)
+
+	AddStateBagChangeHandler('invHotkeys', stateId, function(_, _, value)
+		invHotkeys = value
+	end)
+
+	setStateBagHandler = nil
+end
+
+RegisterNetEvent('txcl:heal', function()
+    if source == '' then return end
+
+    PlayerData.dead = false
+end)
+
+lib.onCache('seat', function(seat)
+	if seat then
+		local hasWeapon = GetCurrentPedVehicleWeapon(cache.ped)
+
+		if hasWeapon then
+			return Utils.WeaponWheel(true)
+		end
+	end
+
+	Utils.WeaponWheel(false)
+end)
+
+lib.onCache('vehicle', function()
+	if invOpen and (not currentInventory.entity or currentInventory.entity == cache.vehicle) then
+		return client.closeInventory()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inventory, weight, player)
+	if source == '' then return end
+
+    ---@class PlayerData
+    ---@field inventory table<number, SlotWithItem?>
+    ---@field weight number
+    ---@field groups table<string, number>
+	PlayerData = player
+	PlayerData.id = cache.playerId
+	PlayerData.source = cache.serverId
+    PlayerData.maxWeight = shared.playerweight
+
+	setmetatable(PlayerData, {
+		__index = function(self, key)
+			if key == 'ped' then
+				return PlayerPedId()
+			end
+		end
+	})
+
+	if setStateBagHandler then setStateBagHandler(('player:%s'):format(cache.serverId)) end
+
+	local ItemData = table.create(0, #Items)
+
+	for _, v in pairs(Items --[[@as table<string, OxClientItem>]]) do
+		local buttons = v.buttons and {} or nil
+
+		if buttons then
+			for i = 1, #v.buttons do
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
+			end
+		end
+
+		ItemData[v.name] = {
+			label = v.label,
+			stack = v.stack,
+			close = v.close,
+			count = 0,
+			description = v.description,
+			buttons = buttons,
+			ammoName = v.ammoname,
+			image = v.client?.image
+		}
+	end
+
+	for _, data in pairs(inventory) do
+		local item = Items[data.name]
+
+		if item then
+			item.count += data.count
+			ItemData[data.name].count += data.count
+			local add = item.client?.add
+
+			if add then
+				add(item.count)
+			end
+		end
+	end
+
+	local phone = Items.phone
+
+	if phone and phone.count < 1 then
+		pcall(function()
+			return exports.npwd:setPhoneDisabled(true)
+		end)
+	end
+
+	client.setPlayerData('inventory', inventory)
+	client.setPlayerData('weight', weight)
+	currentWeapon = nil
+	Weapon.ClearAll()
+
+	local uiLocales = {}
+	local locales = lib.getLocales()
+
+	for k, v in pairs(locales) do
+		if k:find('^ui_')then
+			uiLocales[k] = v
+		end
+	end
+
+	uiLocales['$'] = locales['$']
+	uiLocales.ammo_type = locales.ammo_type
+
+	client.drops = currentDrops
+
+	for dropId, data in pairs(currentDrops) do
+		createDrop(dropId, data)
+	end
+
+	local hasTextUi
+	local uiOptions = { icon = 'fa-id-card' }
+
+	---@param point CPoint
+	local function nearbyLicense(point)
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, 0, true, false, false, false)
+
+		if point.isClosest and point.currentDistance < 1.2 then
+			if not hasTextUi then
+				hasTextUi = point
+				lib.showTextUI(point.message, uiOptions)
+			end
+
+			if IsControlJustReleased(0, 38) then
+				lib.callback('ox_inventory:buyLicense', 1000, function(success, message)
+					if success ~= nil then
+						lib.notify({
+							id = message,
+							type = success == false and 'error' or 'success',
+							description = locale(message, locale('license', point.type:gsub("^%l", string.upper)))
+						})
+					end
+				end, point.invId)
+			end
+		elseif hasTextUi == point then
+			hasTextUi = false
+			lib.hideTextUI()
+		end
+	end
+
+	for id, data in pairs(lib.load('data.licenses') or {}) do
+		lib.points.new({
+			coords = data.coords,
+			distance = 16,
+			inv = 'license',
+			type = data.name,
+			price = data.price,
+			invId = id,
+			nearby = nearbyLicense,
+			message = ('**%s**  \n%s'):format(locale('purchase_license', data.name), locale('interact_prompt', GetControlInstructionalButton(0, 38, true):sub(3)))
+		})
+	end
+
+	while not client.uiLoaded do Wait(50) end
+
+	SendNUIMessage({
+		action = 'init',
+		data = {
+			locale = uiLocales,
+			items = ItemData,
+			leftInventory = {
+				id = cache.playerId,
+				slots = shared.playerslots,
+				items = PlayerData.inventory,
+				maxWeight = shared.playerweight,
+			},
+			imagepath = client.imagepath
+		}
+	})
+
+	PlayerData.loaded = true
+
+	if not client.disablesetupnotification then
+		lib.notify({ description = locale('inventory_setup') })
+	end
+
+	Shops.refreshShops()
+	Inventory.Stashes()
+	Inventory.Evidence()
+
+	if registerCommands then registerCommands() end
+
+	TriggerEvent('ox_inventory:updateInventory', PlayerData.inventory)
+
+	client.interval = SetInterval(function()
+        local canSteal = canOpenTarget(playerPed)
+
+        if canSteal ~= plyState.canSteal then
+            plyState:set('canSteal', canSteal, true)
+        end
+
+		if invOpen == false then
+			playerCoords = GetEntityCoords(playerPed)
+
+			if currentWeapon and IsPedUsingActionMode(playerPed) then
+				SetPedUsingActionMode(playerPed, false, -1, 'DEFAULT_ACTION')
+			end
+
+		elseif invOpen == true then
+			if not canOpenInventory() then
+				client.closeInventory()
+			else
+				playerCoords = GetEntityCoords(playerPed)
+
+				if not currentInventory.ignoreSecurityChecks then
+                    local maxDistance = (currentInventory.distance or currentInventory.type == 'stash' and 4.8 or 1.8) + 0.2
+
+					if currentInventory.type == 'otherplayer' then
+						local id = GetPlayerFromServerId(currentInventory.id --[[@as number]])
+						local ped = GetPlayerPed(id)
+						local pedCoords = GetEntityCoords(ped)
+
+						if not id or #(playerCoords - pedCoords) > maxDistance or (not client.hasGroup(shared.police) and not Player(currentInventory.id).state.canSteal) then
+							client.closeInventory()
+							lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+						else
+							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
+						end
+
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > maxDistance or canSteal) then
+						client.closeInventory()
+						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+					end
+				end
+			end
+		end
+
+		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
+			Utils.DeleteEntity(client.parachute[1])
+			client.parachute = false
+		end
+
+		if EnableWeaponWheel then return end
+
+		local weaponHash = GetSelectedPedWeapon(playerPed)
+
+		if currentWeapon then
+			if weaponHash ~= currentWeapon.hash and currentWeapon.timer then
+				local weaponCount = Items[currentWeapon.name]?.count
+
+				if weaponCount > 0 then
+					SetCurrentPedWeapon(playerPed, currentWeapon.hash, true)
+					SetAmmoInClip(playerPed, currentWeapon.hash, currentWeapon.metadata.ammo)
+					SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+
+					weaponHash = GetSelectedPedWeapon(playerPed)
+				end
+
+				if weaponHash ~= currentWeapon.hash then
+                    lib.print.info(('%s was forcibly unequipped (caused by game behaviour or another resource)'):format(currentWeapon.name))
+					currentWeapon = Weapon.Disarm(currentWeapon, true)
+				end
+			end
+		elseif client.weaponmismatch and not client.ignoreweapons[weaponHash] then
+			local weaponType = GetWeapontypeGroup(weaponHash)
+
+			if weaponType ~= 0 and weaponType ~= `GROUP_UNARMED` then
+				Weapon.Disarm(currentWeapon, true)
+			end
+		end
+	end, 200)
+
+	local playerId = cache.playerId
+	local EnableKeys = client.enablekeys
+	local DisablePlayerVehicleRewards = DisablePlayerVehicleRewards
+	local DisableAllControlActions = DisableAllControlActions
+	local HideHudAndRadarThisFrame = HideHudAndRadarThisFrame
+	local EnableControlAction = EnableControlAction
+	local DisablePlayerFiring = DisablePlayerFiring
+	local HudWeaponWheelIgnoreSelection = HudWeaponWheelIgnoreSelection
+	local DisableControlAction = DisableControlAction
+	local IsPedShooting = IsPedShooting
+	local IsControlJustReleased = IsControlJustReleased
+
+	client.tick = SetInterval(function()
+		DisablePlayerVehicleRewards(playerId)
+
+		if invOpen then
+			DisableAllControlActions(0)
+			HideHudAndRadarThisFrame()
+
+			for i = 1, #EnableKeys do
+				EnableControlAction(0, EnableKeys[i], true)
+			end
+
+			if currentInventory.type == 'drop' or currentInventory.type == 'newdrop' then
+				EnableControlAction(0, 30, true)
+				EnableControlAction(0, 31, true)
+			end
+		else
+			if invBusy then
+				DisableControlAction(0, 23, true)
+				DisableControlAction(0, 36, true)
+			end
+
+			if usingItem or invOpen or IsPedCuffed(playerPed) then
+				DisablePlayerFiring(playerId, true)
+			end
+
+			if not EnableWeaponWheel then
+				HudWeaponWheelIgnoreSelection()
+				DisableControlAction(0, 37, true)
+			end
+
+			if currentWeapon and currentWeapon.timer then
+				DisableControlAction(0, 80, true)
+				DisableControlAction(0, 140, true)
+
+				if currentWeapon.metadata.durability <= 0 or not currentWeapon.timer then
+					DisablePlayerFiring(playerId, true)
+				elseif client.aimedfiring and not currentWeapon.melee and currentWeapon.group ~= `GROUP_PETROLCAN` and not IsPlayerFreeAiming(playerId) then
+					DisablePlayerFiring(playerId, true)
+				end
+
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if not invBusy and currentWeapon.timer ~= 0 and currentWeapon.timer < GetGameTimer() then
+					currentWeapon.timer = 0
+
+					if weaponAmmo then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo)
+
+						if client.autoreload and currentWeapon.ammo and GetAmmoInPedWeapon(playerPed, currentWeapon.hash) == 0 then
+							local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+							if slotId then
+								CreateThread(function() useSlot(slotId) end)
+							end
+						end
+
+					elseif currentWeapon.metadata.durability then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'melee', currentWeapon.melee)
+						currentWeapon.melee = 0
+					end
+				elseif weaponAmmo then
+					if IsPedShooting(playerPed) then
+						local currentAmmo
+						local durabilityDrain = Items[currentWeapon.name].durability
+
+						if currentWeapon.group == `GROUP_PETROLCAN` or currentWeapon.group == `GROUP_FIREEXTINGUISHER` then
+							currentAmmo = weaponAmmo - durabilityDrain < 0 and 0 or weaponAmmo - durabilityDrain
+							currentWeapon.metadata.durability = currentAmmo
+							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+
+							if currentAmmo <= 0 then
+								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+							end
+						else
+							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+
+							if currentAmmo < weaponAmmo then
+								currentAmmo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+								currentWeapon.metadata.ammo = currentAmmo
+								currentWeapon.metadata.durability = currentWeapon.metadata.durability - (durabilityDrain * math.abs((weaponAmmo or 0.1) - currentAmmo))
+							end
+						end
+
+						if currentAmmo <= 0 then
+							if cache.vehicle then
+								TaskSwapWeapon(playerPed, true)
+							end
+
+							currentWeapon.timer = GetGameTimer() + 200
+						else currentWeapon.timer = GetGameTimer() + (GetWeaponTimeBetweenShots(currentWeapon.hash) * 1000) + 100 end
+					end
+				elseif currentWeapon.throwable then
+					if not invBusy and IsControlPressed(0, 24) then
+						invBusy = 1
+
+						CreateThread(function()
+							local weapon = currentWeapon
+
+							while currentWeapon and (not IsPedWeaponReadyToShoot(cache.ped) or IsDisabledControlPressed(0, 24)) and GetSelectedPedWeapon(playerPed) == weapon.hash do
+								Wait(0)
+							end
+
+							if GetSelectedPedWeapon(playerPed) == weapon.hash then Wait(700) end
+
+							while IsPedPlantingBomb(playerPed) do Wait(0) end
+
+							TriggerServerEvent('ox_inventory:updateWeapon', 'throw', nil, weapon.slot)
+							plyState:set('invBusy', false, true)
+
+							currentWeapon = nil
+
+							RemoveWeaponFromPed(playerPed, weapon.hash)
+							TriggerEvent('ox_inventory:currentWeapon')
+						end)
+					end
+				elseif currentWeapon.melee and IsControlJustReleased(0, 24) and IsPedPerformingMeleeAction(playerPed) then
+					currentWeapon.melee += 1
+					currentWeapon.timer = GetGameTimer() + 200
+				end
+			end
+		end
+	end)
+
+	plyState:set('invBusy', false, true)
+	plyState:set('invOpen', false, false)
+	plyState:set('invHotkeys', true, false)
+	plyState:set('canUseWeapons', true, false)
+	collectgarbage('collect')
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if shared.resource == resourceName then
+		client.onLogout()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+    currentInventory.type = 'inspect'
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+RegisterNUICallback('uiLoaded', function(_, cb)
+	client.uiLoaded = true
+	cb(1)
+end)
+
+RegisterNUICallback('getItemData', function(itemName, cb)
+	cb(Items[itemName])
+end)
+
+RegisterNUICallback('removeComponent', function(data, cb)
+	cb(1)
+
+	if not currentWeapon then
+		return TriggerServerEvent('ox_inventory:updateWeapon', 'component', data)
+	end
+
+	if data.slot ~= currentWeapon.slot then
+		return lib.notify({ id = 'weapon_hand_wrong', type = 'error', description = locale('weapon_hand_wrong') })
+	end
+
+	local itemSlot = PlayerData.inventory[currentWeapon.slot]
+
+    if not itemSlot then return end
+
+	for _, component in pairs(Items[data.component].client.component) do
+		if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+			for k, v in pairs(itemSlot.metadata.components) do
+				if v == data.component then
+					local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', k)
+
+					if success then
+						RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, component)
+						TriggerEvent('ox_inventory:updateWeaponComponent', 'removed', component, data.component)
+					end
+
+					break
+				end
+			end
+		end
+	end
+end)
+
+RegisterNUICallback('removeAmmo', function(slot, cb)
+	cb(1)
+	local slotData = PlayerData.inventory[slot]
+
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo == 0 then return end
+
+	local success = lib.callback.await('ox_inventory:removeAmmoFromWeapon', false, slot)
+
+	if success and slot == currentWeapon?.slot then
+		SetPedAmmo(playerPed, currentWeapon.hash, 0)
+	end
+end)
+
+RegisterNUICallback('useItem', function(slot, cb)
+	useSlot(slot --[[@as number]])
+	cb(1)
+end)
+
+local function giveItemToTarget(serverId, slotId, count)
+    if type(slotId) ~= 'number' then return TypeError('slotId', 'number', type(slotId)) end
+    if count and type(count) ~= 'number' then return TypeError('count', 'number', type(count)) end
+
+    if slotId == currentWeapon?.slot then
+        currentWeapon = Weapon.Disarm(currentWeapon)
+    end
+
+    Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 1.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+
+    local notification = lib.callback.await('ox_inventory:giveItem', false, slotId, serverId, count or 0)
+
+    if notification then
+        lib.notify({ type = 'error', description = locale(table.unpack(notification)) })
+    end
+end
+
+exports('giveItemToTarget', giveItemToTarget)
+
+local function isGiveTargetValid(ped, coords)
+    if cache.vehicle and GetVehiclePedIsIn(ped, false) == cache.vehicle then
+        return true
+    end
+
+    local entity = Utils.Raycast(1|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
+
+    return entity == ped and IsEntityVisible(ped)
+end
+
+RegisterNUICallback('giveItem', function(data, cb)
+	cb(1)
+
+    if usingItem then return end
+
+	if client.giveplayerlist then
+		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
+
+		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
+        local nearbyCount = #nearbyPlayers
+
+		if nearbyCount == 0 then return end
+
+        if nearbyCount == 1 then
+			local option = nearbyPlayers[1]
+
+            if not isGiveTargetValid(option.ped, option.coords) then return end
+
+            return giveItemToTarget(GetPlayerServerId(option.id), data.slot, data.count)
+        end
+
+        local giveList, n = {}, 0
+
+		for i = 1, #nearbyPlayers do
+			local option = nearbyPlayers[i]
+
+            if isGiveTargetValid(option.ped, option.coords) then
+				local playerName = Utils.getPlayerName(option.id)
+				option.id = GetPlayerServerId(option.id)
+                ---@diagnostic disable-next-line: inject-field
+				option.label = playerName
+				n += 1
+				giveList[n] = option
+			end
+		end
+
+        if n == 0 then return end
+
+		lib.registerMenu({
+			id = 'ox_inventory:givePlayerList',
+			title = 'Give item',
+			options = giveList,
+		}, function(selected)
+            giveItemToTarget(giveList[selected].id, data.slot, data.count)
+        end)
+
+		return lib.showMenu('ox_inventory:givePlayerList')
+	end
+
+    if cache.vehicle then
+		local seats = GetVehicleMaxNumberOfPassengers(cache.vehicle) - 1
+
+		if seats >= 0 then
+			local passenger = GetPedInVehicleSeat(cache.vehicle, cache.seat - 2 * (cache.seat % 2) + 1)
+
+			if passenger ~= 0 and IsEntityVisible(passenger) then
+                return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(passenger)), data.slot, data.count)
+			end
+		end
+
+        return
+	end
+
+    local entity = Utils.Raycast(1|2|4|8|16, GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 3.0, 0.5), 0.2)
+
+    if entity and IsPedAPlayer(entity) and IsEntityVisible(entity) and #(GetEntityCoords(playerPed, true) - GetEntityCoords(entity, true)) < 3.0 then
+        return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(entity)), data.slot, data.count)
+    end
+end)
+
+RegisterNUICallback('useButton', function(data, cb)
+	useButton(data.id, data.slot)
+	cb(1)
+end)
+
+RegisterNUICallback('exit', function(_, cb)
+	client.closeInventory()
+	cb(1)
+end)
+
+lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
+	recipe = CraftingBenches[id].items[recipe]
+
+	return lib.progressCircle({
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
+		duration = recipe.duration or 3000,
+		canCancel = true,
+		disable = {
+			move = true,
+			combat = true,
+		},
+		anim = {
+			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+			clip = 'machinic_loop_mechandplayer',
+		}
+	})
+end)
+
+local swapActive = false
+
+---Synchronise and validate all item movement between the NUI and server.
+RegisterNUICallback('swapItems', function(data, cb)
+    if swapActive or not invOpen or invBusy or usingItem then return cb(false) end
+
+    swapActive = true
+
+	if data.toType == 'newdrop' then
+		if cache.vehicle or IsPedFalling(playerPed) then
+			swapActive = false
+			return cb(false)
+		end
+
+		local coords = GetEntityCoords(playerPed)
+
+		if IsEntityInWater(playerPed) then
+			local destination = vec3(coords.x, coords.y, -200)
+			local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z, 511, cache.ped, 4)
+
+			while true do
+				Wait(0)
+				local retval, hit, endCoords = GetShapeTestResult(handle)
+
+				if retval ~= 1 then
+					if not hit then return end
+
+					data.coords = vec3(endCoords.x, endCoords.y, endCoords.z + 1.0)
+
+					break
+				end
+			end
+		else
+			data.coords = coords
+		end
+    end
+
+	if currentInstance then
+		data.instance = currentInstance
+	end
+
+	if currentWeapon and data.fromType ~= data.toType then
+		if (data.fromType == 'player' and data.fromSlot == currentWeapon.slot) or (data.toType == 'player' and data.toSlot == currentWeapon.slot) then
+			currentWeapon = Weapon.Disarm(currentWeapon, true)
+		end
+	end
+
+	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
+    swapActive = false
+
+	cb(success or false)
+
+	if success then
+        if weaponSlot and currentWeapon then
+            currentWeapon.slot = weaponSlot
+        end
+
+		if response then
+			updateInventory(response.items, response.weight)
+		end
+	elseif response then
+		if type(response) == 'table' then
+			SendNUIMessage({ action = 'refreshSlots', data = { items = response } })
+		else
+			lib.notify({ type = 'error', description = locale(response) })
+		end
+	end
+end)
+
+RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
+	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
+
+	if data then
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
+	end
+
+	if message then
+		lib.notify(message)
+	end
+
+	cb(response)
+end)
+
+RegisterNUICallback('craftItem', function(data, cb)
+	cb(true)
+
+	local id, index = currentInventory.id, currentInventory.index
+
+	for i = 1, data.count do
+		local success, response = lib.callback.await('ox_inventory:craftItem', 200, id, index, data.fromSlot, data.toSlot)
+
+		if not success then
+			if response then lib.notify({ type = 'error', description = locale(response or 'cannot_perform') }) end
+			break
+		end
+	end
+
+	if currentInventory.type ~= 'crafting' then
+		client.openInventory('crafting', { id = id, index = index })
+	end
+end)
+
+lib.callback.register('ox_inventory:getVehicleData', function(netid)
+	local entity = NetworkGetEntityFromNetworkId(netid)
+
+	if entity then
+		return GetEntityModel(entity), GetVehicleClass(entity)
+	end
+end)

--- a/2.47.0/modules/utils/client.lua
+++ b/2.47.0/modules/utils/client.lua
@@ -1,0 +1,312 @@
+if not lib then return end
+
+local Utils = {}
+
+--Holgers Anpassungen
+Utils.Waffensyncaus = false
+--Holgers Anpassungen bis hier
+
+function Utils.PlayAnim(wait, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(cache.ped, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+                                time)
+    lib.requestAnimDict(dict)
+    TaskPlayAnimAdvanced(cache.ped, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+        time, 0, 0)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+---@param flag number
+---@param destination? vector3
+---@param size? number
+---@return number | false
+---@return number?
+function Utils.Raycast(flag, destination, size)
+    local playerCoords = GetEntityCoords(cache.ped)
+    destination = destination or GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)
+    local rayHandle = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x,
+        destination.y, destination.z, size or 2.2, flag or 30, cache.ped, 4)
+    while true do
+        Wait(0)
+        local result, _, coords, _, entityHit = GetShapeTestResult(rayHandle)
+        if result ~= 1 then
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x, destination.y, destination.z, 0, 0, 255, 255)
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, coords.x, coords.y, coords.z, 255, 0, 0, 255)
+            local entityType
+            if entityHit then entityType = GetEntityType(entityHit) end
+            if entityHit and entityType ~= 0 then
+                return entityHit, entityType
+            end
+            return false
+        end
+    end
+end
+
+function Utils.GetClosestPlayer()
+    local players = GetActivePlayers()
+    local playerCoords = GetEntityCoords(cache.ped)
+    local targetDistance, targetId, targetPed
+
+    for i = 1, #players do
+        local player = players[i]
+
+        if player ~= cache.playerId then
+            local ped = GetPlayerPed(player)
+            local distance = #(playerCoords - GetEntityCoords(ped))
+
+            if distance < (targetDistance or 2) then
+                targetDistance = distance
+                targetId = player
+                targetPed = ped
+            end
+        end
+    end
+
+    return targetId, targetPed
+end
+
+-- Replace ox_inventory notify with ox_lib (backwards compatibility)
+function Utils.Notify(data)
+    data.description = data.text
+    data.text = nil
+    lib.notify(data)
+end
+
+RegisterNetEvent('ox_inventory:notify', Utils.Notify)
+exports('notify', Utils.Notify)
+
+local notifySuppressed = false
+
+---@param value boolean
+local function setNotifySuppressed(value)
+    notifySuppressed = value
+end
+
+RegisterNetEvent('ox_inventory:suppressItemNotifications', setNotifySuppressed)
+exports('suppressItemNotifications', setNotifySuppressed)
+
+function Utils.ItemNotify(data)
+    if notifySuppressed or not client.itemnotify then
+        return
+    end
+
+    SendNUIMessage({ action = 'itemNotify', data = data })
+end
+
+RegisterNetEvent('ox_inventory:itemNotify', Utils.ItemNotify)
+
+---@deprecated
+function Utils.DeleteObject(obj)
+    SetEntityAsMissionEntity(obj, false, true)
+    DeleteObject(obj)
+end
+
+function Utils.DeleteEntity(entity)
+    if DoesEntityExist(entity) then
+        SetEntityAsMissionEntity(entity, false, true)
+        DeleteEntity(entity)
+    end
+end
+
+local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
+
+local weaponWheelOverride = false
+
+---Enables the weapon wheel, but disables the use of inventory weapons.
+---Mostly used for weaponised vehicles, though could be called for "minigames"
+---@param state? boolean
+---@param override? boolean
+function Utils.WeaponWheel(state, override)
+    if not override and weaponWheelOverride and state == false then
+        return
+    end
+    if client.disableweapons then state = true end
+    if state == nil then state = EnableWeaponWheel end
+
+    if override then
+        weaponWheelOverride = state or false
+    end
+
+    EnableWeaponWheel = state
+    SetWeaponsNoAutoswap(not state)
+    SetWeaponsNoAutoreload(not state)
+
+    if client.suppresspickups then
+        -- CLEAR_PICKUP_REWARD_TYPE_SUPPRESSION | SUPPRESS_PICKUP_REWARD_TYPE
+        return state and N_0x762db2d380b48d04(rewardTypes) or N_0xf92099527db8e2a7(rewardTypes, true)
+    end
+end
+
+exports('weaponWheel', function (state)
+    Utils.WeaponWheel(state, true)
+end)
+
+--Holgers part starts
+
+function Utils.Waffensyncdisable(state)
+	if state == nil then state = Utils.Waffensyncaus end
+	Utils.Waffensyncaus = state
+	Utils.WeaponWheelsyncen()
+end
+
+Utils.WeaponWheelundHotbar = function(state)
+	if state == nil then state = HotbarundWeaponWheel end
+	HotbarundWeaponWheel = state
+	Utils.WeaponWheel(state)
+end
+
+Utils.WeaponWheelsyncen = function ()
+	Utils.ClearWeapons()
+	if not Utils.Waffensyncaus then		
+		Wait(500)
+		local items = exports.ox_inventory:GetPlayerItems()
+		if items ~=nil  then
+			Waffencache = nil
+			Waffencache = {}
+			for k,v in pairs(items) do
+				if string.sub(v.name,1,7) =="WEAPON_"  and v.name ~= "WEAPON_PETROLCAN" then
+					if HasPedGotWeapon(cache.ped,v.name,false) then
+						RemoveWeaponFromPed(cache.ped,v.name)
+					end
+					local hash = GetHashKey(v.name)
+					Waffencache[hash] = {}
+					Waffencache[hash].name = v.name
+					Waffencache[hash].slot = v.slot
+					Waffencache[hash].hash = hash
+
+					GiveWeaponToPed(cache.ped,v.name,1,false,false)
+				end
+			end
+		end
+	end
+end
+
+exports('Weaponsyncdisable', Utils.Waffensyncdisable)
+exports('WeaponWheelandHotbar', Utils.WeaponWheelundHotbar)
+
+--Holgers part ends
+
+function Utils.CreateBlip(settings, coords)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, settings.id)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, settings.scale)
+    SetBlipColour(blip, settings.colour)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName(settings.name)
+    EndTextCommandSetBlipName(blip)
+
+    return blip
+end
+
+---Takes OxTargetBoxZone or legacy zone data (PolyZone) and creates a zone.
+---@param data OxTargetBoxZone | { length: number, minZ: number, maxZ: number, loc: vector3, heading: number, width: number, distance: number }
+---@param options? OxTargetOption[]
+---@return number
+function Utils.CreateBoxZone(data, options)
+    if data.length then
+        local height = math.abs(data.maxZ - data.minZ)
+        local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2
+        data.coords = vec3(data.loc.x, data.loc.y, z)
+        data.size = vec3(data.width, data.length, height)
+        data.rotation = data.heading
+        data.loc = nil
+        data.heading = nil
+        data.length = nil
+        data.width = nil
+        data.maxZ = nil
+        data.minZ = nil
+    end
+
+    if not data.options and options then
+        local distance = data.distance or 2.0
+
+        for k, v in pairs(options) do
+            if not v.distance then
+                v.distance = distance
+            end
+        end
+
+        data.options = options
+    end
+
+    return exports.ox_target:addBoxZone(data)
+end
+
+local hasTextUi
+
+---@param point CPoint
+function Utils.nearbyMarker(point)
+    DrawMarker(point.marker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, point.marker.scale[1], point.marker.scale[2], point.marker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        point.marker.colour[1], point.marker.colour[2], point.marker.colour[3], 222, false, false, 0, true, false, false, false)
+
+    if point.isClosest and point.currentDistance < 1.2 then
+        if not hasTextUi then
+            hasTextUi = point
+            lib.showTextUI(point.prompt.message, point.prompt.options)
+        end
+
+        if IsControlJustReleased(0, 38) then
+            CreateThread(function()
+                if point.inv == 'policeevidence' then
+                    client.openInventory('policeevidence')
+                elseif point.inv == 'crafting' then
+                    client.openInventory('crafting', { id = point.benchid, index = point.index })
+                else
+                    client.openInventory(point.inv or 'drop', { id = point.invId, type = point.type })
+                end
+            end)
+        end
+    elseif hasTextUi == point then
+        hasTextUi = nil
+        lib.hideTextUI()
+    end
+end
+
+function Utils.blurIn()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeIn(100)
+end
+
+function Utils.blurOut()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeOut(250)
+end
+
+---@param serverID number
+---@return string
+local function defaultGetPlayerName(serverID)
+    local playerName = GetPlayerName(serverID)
+    return ('[%d] %s'):format(serverID, playerName)
+end
+
+local getPlayerName = defaultGetPlayerName
+
+exports('setGetPlayerNameMethod', function (fn)
+    if type(fn) == "function" then
+        getPlayerName = fn
+    else
+        getPlayerName = defaultGetPlayerName
+    end
+end)
+
+function Utils.getPlayerName(serverId)
+    return getPlayerName(serverId)
+end
+
+return Utils

--- a/2.47.0/modules/weapon/client.lua
+++ b/2.47.0/modules/weapon/client.lua
@@ -1,0 +1,666 @@
+if not lib then return end
+
+local Weapon = {}
+local Items = require 'modules.items.client'
+local Utils = require 'modules.utils.client'
+
+-- generic group animation data
+local anims = {}
+anims[`GROUP_MELEE`] = { 'melee@holster', 'unholster', 200, 'melee@holster', 'holster', 600 }
+anims[`GROUP_PISTOL`] = { 'reaction@intimidation@cop@unarmed', 'intro', 400, 'reaction@intimidation@cop@unarmed', 'outro', 450 }
+anims[`GROUP_STUNGUN`] = anims[`GROUP_PISTOL`]
+
+local function vehicleIsCycle(vehicle)
+	local class = GetVehicleClass(vehicle)
+	return class == 8 or class == 13
+end
+
+function Weapon.Equip(item, data, noWeaponAnim)
+	local playerPed = cache.ped
+	local coords = GetEntityCoords(playerPed, true)
+    local sleep
+
+	if client.weaponanims then
+		if noWeaponAnim or (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			goto skipAnim
+		end
+
+		local anim = data.anim or anims[GetWeapontypeGroup(data.hash)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+		sleep = anim and anim[3] or 1200
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+	end
+
+	::skipAnim::
+
+	GiveWeaponToPed(playerPed, -1569615261, 0, false, true) --added by Holger
+
+	item.hash = data.hash
+	item.ammo = data.ammoname
+	item.melee = GetWeaponDamageType(data.hash) == 2 and 0
+	item.timer = 0
+	item.throwable = data.throwable
+	item.group = GetWeapontypeGroup(item.hash)
+
+	GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+
+	if item.metadata.tint then SetPedWeaponTintIndex(playerPed, data.hash, item.metadata.tint) end
+
+	if item.metadata.components then
+		for i = 1, #item.metadata.components do
+			local components = Items[item.metadata.components[i]].client.component
+			for v=1, #components do
+				local component = components[v]
+				if DoesWeaponTakeWeaponComponent(data.hash, component) then
+					if not HasPedGotWeaponComponent(playerPed, data.hash, component) then
+						GiveWeaponComponentToPed(playerPed, data.hash, component)
+					end
+				end
+			end
+		end
+	end
+
+	if item.metadata.specialAmmo then
+		local clipComponentKey = ('%s_CLIP'):format(data.model:gsub('WEAPON_', 'COMPONENT_'))
+		local specialClip = ('%s_%s'):format(clipComponentKey, item.metadata.specialAmmo:upper())
+
+		if DoesWeaponTakeWeaponComponent(data.hash, specialClip) then
+			GiveWeaponComponentToPed(playerPed, data.hash, specialClip)
+		end
+	end
+
+	local ammo = item.metadata.ammo or item.throwable and 1 or 0
+
+	SetCurrentPedWeapon(playerPed, data.hash, true)
+	SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+	SetWeaponsNoAutoswap(true)
+	SetPedAmmo(playerPed, data.hash, ammo)
+	SetTimeout(0, function() RefillAmmoInstantly(playerPed) end)
+
+	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
+		item.metadata.ammo = item.metadata.durability
+		SetPedInfiniteAmmo(playerPed, true, data.hash)
+	end
+
+	TriggerEvent('ox_inventory:currentWeapon', item)
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
+
+	return item, sleep
+end
+
+function Weapon.Disarm(currentWeapon, noAnim, waffenlos) --waffenlos added by Holger
+	if currentWeapon?.timer then
+		currentWeapon.timer = nil
+
+        TriggerServerEvent('ox_inventory:updateWeapon')
+		--SetPedAmmo(cache.ped, currentWeapon.hash, 0)	--disabled by Holger
+
+		if client.weaponanims and not noAnim then
+			if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+				goto skipAnim
+			end
+
+			ClearPedSecondaryTask(cache.ped)
+
+			local item = Items[currentWeapon.name]
+			local coords = GetEntityCoords(cache.ped, true)
+			local anim = item.anim or anims[GetWeapontypeGroup(currentWeapon.hash)]
+
+			if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+				anim = nil
+			end
+
+			local sleep = anim and anim[6] or 1400
+
+			Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+		end
+
+		::skipAnim::
+
+		if waffenlos then	--if added by Holger
+			GiveWeaponToPed(cache.ped, currentWeapon.hash, 0, false, true)
+		end
+
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
+		TriggerEvent('ox_inventory:currentWeapon')
+	end
+
+end --closing end for Weapon.Disarm
+
+--[[ 	Utils.WeaponWheel() --disabled by Holger
+	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
+	end
+end ]]
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+
+--Holgers part starts
+
+
+Weapon.triggerAnimation = function(waffenhashalt,waffenhashneu,wert)
+	if wert then
+		local playerPed = cache.ped
+		local coords = GetEntityCoords(playerPed, true)
+		local sleep
+
+		if  (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			return
+		end
+
+		local anim = anims[GetWeapontypeGroup(waffenhashneu)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+
+		sleep = anim and anim[3] or 1100
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+
+		GiveWeaponToPed(playerPed, waffenhashneu, 250, false, true)
+		sleep = 0
+
+	else
+		if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+			return
+		end
+		local sleep
+
+
+		ClearPedSecondaryTask(cache.ped)
+
+		local coords = GetEntityCoords(cache.ped, true)
+		local anim = anims[GetWeapontypeGroup(waffenhashalt)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		local sleep = anim and anim[6] or 1000
+
+		GiveWeaponToPed(cache.ped, waffenhashalt, 0, false, true)
+		
+		Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+	end
+
+end
+
+--Holgers part ends
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+--added by Holger thanks to 5Labs for providing the list
+
+Weapon.WeaponByHash = {
+	[-1768145561] = {
+	["name"] = 'WEAPON_SPECIALCARBINE_MK2',
+	["label"] = 'Special Carbine MK2',
+	},
+	[487013001] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN',
+	["label"] = 'Pump Shotgun',
+	},
+	[-1075685676] = {
+	["name"] = 'WEAPON_PISTOL_MK2',
+	["label"] = 'Pistol MK2',
+	},
+	[-1238556825] = {
+	["name"] = 'WEAPON_RAYMINIGUN',
+	["label"] = 'Widowmaker',
+	},
+	[-1834847097] = {
+	["name"] = 'WEAPON_DAGGER',
+	["label"] = 'Dagger',
+	},
+	[-2067956739] = {
+	["name"] = 'WEAPON_CROWBAR',
+	["label"] = 'Crowbar',
+	},
+	[650961374] = {
+	["name"] = 'WEAPON_TEARGAS',
+	["label"] = 'Tear Gas',
+	},
+	[-618237638] = {
+	["name"] = 'WEAPON_EMPLAUNCHER',
+	["label"] = 'Compact EMP Launcher',
+	},
+	[-2084633992] = {
+	["name"] = 'WEAPON_CARBINERIFLE',
+	["label"] = 'Carbine Rifle',
+	},
+	[940833800] = {
+	["name"] = 'WEAPON_STONE_HATCHET',
+	["label"] = 'Stone Hatchet',
+	},
+	[-1716589765] = {
+	["name"] = 'WEAPON_PISTOL50',
+	["label"] = 'Pistol .50',
+	},
+	[-1716189206] = {
+	["name"] = 'WEAPON_KNIFE',
+	["label"] = 'Knife',
+	},
+	[1853742572] = {
+	["name"] = 'WEAPON_PRECISIONRIFLE',
+	["label"] = 'Precision Rifle',
+	},
+	[-1076751822] = {
+	["name"] = 'WEAPON_SNSPISTOL',
+	["label"] = 'SNS Pistol',
+	},
+	[1198879012] = {
+	["name"] = 'WEAPON_FLAREGUN',
+	["label"] = 'Flare Gun',
+	},
+	[-1355376991] = {
+	["name"] = 'WEAPON_RAYPISTOL',
+	["label"] = 'Up-n-Atomizer',
+	},
+	[-1813897027] = {
+	["name"] = 'WEAPON_GRENADE',
+	["label"] = 'Grenade',
+	},
+	[1737195953] = {
+	["name"] = 'WEAPON_NIGHTSTICK',
+	["label"] = 'Nightstick',
+	},
+	[1198256469] = {
+	["name"] = 'WEAPON_RAYCARBINE',
+	["label"] = 'Unholy Hellbringer',
+	},
+	[465894841] = {
+	["name"] = 'WEAPON_PISTOLXM3',
+	["label"] = 'WM 29 Pistol',
+	},
+	[1432025498] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN_MK2',
+	["label"] = 'Pump Shotgun MK2',
+	},
+	[100416529] = {
+	["name"] = 'WEAPON_SNIPERRIFLE',
+	["label"] = 'Sniper Rifle',
+	},
+	[1593441988] = {
+	["name"] = 'WEAPON_COMBATPISTOL',
+	["label"] = 'Glock',
+	},
+	[-581044007] = {
+	["name"] = 'WEAPON_MACHETE',
+	["label"] = 'Machete',
+	},
+	[-275439685] = {
+	["name"] = 'WEAPON_DBSHOTGUN',
+	["label"] = 'Double Barrel Shotgun',
+	},
+	[-1063057011] = {
+	["name"] = 'WEAPON_SPECIALCARBINE',
+	["label"] = 'Special Carbine',
+	},
+	[-1951375401] = {
+	["name"] = 'WEAPON_FLASHLIGHT',
+	["label"] = 'Flashlight',
+	},
+	[727643628] = {
+	["name"] = 'WEAPON_CERAMICPISTOL',
+	["label"] = 'Ceramic Pistol',
+	},
+	[584646201] = {
+	["name"] = 'WEAPON_APPISTOL',
+	["label"] = 'AP Pistol',
+	},
+	[-1045183535] = {
+	["name"] = 'WEAPON_REVOLVER',
+	["label"] = 'Revolver',
+	},
+	[-22923932] = {
+	["name"] = 'WEAPON_RAILGUNXM3',
+	["label"] = 'Railgun XM3',
+	},
+	[324215364] = {
+	["name"] = 'WEAPON_MICROSMG',
+	["label"] = 'Micro SMG',
+	},
+	[-1600701090] = {
+	["name"] = 'WEAPON_BZGAS',
+	["label"] = 'BZ Gas',
+	},
+	[-1168940174] = {
+	["name"] = 'WEAPON_HAZARDCAN',
+	["label"] = 'Hazard Can',
+	},
+	[-608341376] = {
+	["name"] = 'WEAPON_COMBATMG_MK2',
+	["label"] = 'Combat MG MK2',
+	},
+	[-538741184] = {
+	["name"] = 'WEAPON_SWITCHBLADE',
+	["label"] = 'Switchblade',
+	},
+	[984333226] = {
+	["name"] = 'WEAPON_HEAVYSHOTGUN',
+	["label"] = 'Heavy Shotgun',
+	},
+	[1785463520] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE_MK2',
+	["label"] = 'Marksman Rifle MK2',
+	},
+	[2024373456] = {
+	["name"] = 'WEAPON_SMG_MK2',
+	["label"] = 'SMG Mk2',
+	},
+	[1649403952] = {
+	["name"] = 'WEAPON_COMPACTRIFLE',
+	["label"] = 'Compact Rifle',
+	},
+	[615608432] = {
+	["name"] = 'WEAPON_MOLOTOV',
+	["label"] = 'Molotov',
+	},
+	[600439132] = {
+	["name"] = 'WEAPON_BALL',
+	["label"] = 'Ball',
+	},
+	[-952879014] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE',
+	["label"] = 'Marksman Rifle',
+	},
+	[-610080759] = {
+	["name"] = 'WEAPON_METALDETECTOR',
+	["label"] = 'Metal Detector',
+	},
+	[2017895192] = {
+	["name"] = 'WEAPON_SAWNOFFSHOTGUN',
+	["label"] = 'Sawn Off Shotgun',
+	},
+	[-1568386805] = {
+	["name"] = 'WEAPON_GRENADELAUNCHER',
+	["label"] = 'Grenade Launcher',
+	},
+	[-270015777] = {
+	["name"] = 'WEAPON_ASSAULTSMG',
+	["label"] = 'Assault SMG',
+	},
+	[-1466123874] = {
+	["name"] = 'WEAPON_MUSKET',
+	["label"] = 'Musket',
+	},
+	[-37975472] = {
+	["name"] = 'WEAPON_SMOKEGRENADE',
+	["label"] = 'Smoke Grenade',
+	},
+	[-1654528753] = {
+	["name"] = 'WEAPON_BULLPUPSHOTGUN',
+	["label"] = 'Bullpup Shotgun',
+	},
+	[1317494643] = {
+	["name"] = 'WEAPON_HAMMER',
+	["label"] = 'Hammer',
+	},
+	[137902532] = {
+	["name"] = 'WEAPON_VINTAGEPISTOL',
+	["label"] = 'Vintage Pistol',
+	},
+	[-853065399] = {
+	["name"] = 'WEAPON_BATTLEAXE',
+	["label"] = 'Battle Axe',
+	},
+	[-1660422300] = {
+	["name"] = 'WEAPON_MG',
+	["label"] = 'Machine Gun',
+	},
+	[1470379660] = {
+	["name"] = 'WEAPON_GADGETPISTOL',
+	["label"] = 'Perico Pistol',
+	},
+	[-1853920116] = {
+	["name"] = 'WEAPON_NAVYREVOLVER',
+	["label"] = 'Navy Revolver',
+	},
+	[94989220] = {
+	["name"] = 'WEAPON_COMBATSHOTGUN',
+	["label"] = 'Combat Shotgun',
+	},
+	[2144741730] = {
+	["name"] = 'WEAPON_COMBATMG',
+	["label"] = 'Combat MG',
+	},
+	[317205821] = {
+	["name"] = 'WEAPON_AUTOSHOTGUN',
+	["label"] = 'Sweeper Shotgun',
+	},
+	[883325847] = {
+	["name"] = 'WEAPON_PETROLCAN',
+	["label"] = 'Gas Can',
+	},
+	[-1357824103] = {
+	["name"] = 'WEAPON_ADVANCEDRIFLE',
+	["label"] = 'Advanced Rifle',
+	},
+	[736523883] = {
+	["name"] = 'WEAPON_SMG',
+	["label"] = 'SMG',
+	},
+	[205991906] = {
+	["name"] = 'WEAPON_HEAVYSNIPER',
+	["label"] = 'Heavy Sniper',
+	},
+	[-1312131151] = {
+	["name"] = 'WEAPON_RPG',
+	["label"] = 'RPG',
+	},
+	[-771403250] = {
+	["name"] = 'WEAPON_HEAVYPISTOL',
+	["label"] = 'Heavy Pistol',
+	},
+	[-879347409] = {
+	["name"] = 'WEAPON_REVOLVER_MK2',
+	["label"] = 'Revolver MK2',
+	},
+	[-494615257] = {
+	["name"] = 'WEAPON_ASSAULTSHOTGUN',
+	["label"] = 'Assault Shotgun',
+	},
+	[-947031628] = {
+	["name"] = 'WEAPON_HEAVYRIFLE',
+	["label"] = 'Heavy Rifle',
+	},
+	[-1420407917] = {
+	["name"] = 'WEAPON_PROXMINE',
+	["label"] = 'Proximity Mine',
+	},
+	[-619010992] = {
+	["name"] = 'WEAPON_MACHINEPISTOL',
+	["label"] = 'Machine Pistol',
+	},
+	[-1746263880] = {
+	["name"] = 'WEAPON_DOUBLEACTION',
+	["label"] = 'Double Action Revolver',
+	},
+	[125959754] = {
+	["name"] = 'WEAPON_COMPACTLAUNCHER',
+	["label"] = 'Compact Grenade Launcher',
+	},
+	[2132975508] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE',
+	["label"] = 'Bullpup Rifle',
+	},
+	[-86904375] = {
+	["name"] = 'WEAPON_CARBINERIFLE_MK2',
+	["label"] = 'Carbine Rifle MK2',
+	},
+	[453432689] = {
+	["name"] = 'WEAPON_PISTOL',
+	["label"] = 'Pistol',
+	},
+	[-1074790547] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE',
+	["label"] = 'Assault Rifle',
+	},
+	[1627465347] = {
+	["name"] = 'WEAPON_GUSENBERG',
+	["label"] = 'Gusenberg',
+	},
+	[911657153] = {
+	["name"] = 'WEAPON_STUNGUN',
+	["label"] = 'Tazer',
+	},
+	[-1121678507] = {
+	["name"] = 'WEAPON_MINISMG',
+	["label"] = 'Mini SMG',
+	},
+	[171789620] = {
+	["name"] = 'WEAPON_COMBATPDW',
+	["label"] = 'Combat PDW',
+	},
+	[1141786504] = {
+	["name"] = 'WEAPON_GOLFCLUB',
+	["label"] = 'Golf Club',
+	},
+	[1834241177] = {
+	["name"] = 'WEAPON_RAILGUN',
+	["label"] = 'Railgun',
+	},
+	[1119849093] = {
+	["name"] = 'WEAPON_MINIGUN',
+	["label"] = 'Minigun',
+	},
+	[961495388] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE_MK2',
+	["label"] = 'Assault Rifle MK2',
+	},
+	[406929569] = {
+	["name"] = 'WEAPON_FERTILIZERCAN',
+	["label"] = 'Fertilizer Can',
+	},
+	[1233104067] = {
+	["name"] = 'WEAPON_FLARE',
+	["label"] = 'Flare',
+	},
+	[419712736] = {
+	["name"] = 'WEAPON_WRENCH',
+	["label"] = 'Wrench',
+	},
+	[-2009644972] = {
+	["name"] = 'WEAPON_SNSPISTOL_MK2',
+	["label"] = 'SNS Pistol MK2',
+	},
+	[-102973651] = {
+	["name"] = 'WEAPON_HATCHET',
+	["label"] = 'Hatchet',
+	},
+	[-2066285827] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE_MK2',
+	["label"] = 'Bullpup Rifle MK2',
+	},
+	[-1169823560] = {
+	["name"] = 'WEAPON_PIPEBOMB',
+	["label"] = 'Pipe Bomb',
+	},
+	[1703483498] = {
+	["name"] = 'WEAPON_CANDYCANE',
+	["label"] = 'Candy Cane',
+	},
+	[-598887786] = {
+	["name"] = 'WEAPON_MARKSMANPISTOL',
+	["label"] = 'Marksman Pistol',
+	},
+	[350597077] = {
+	["name"] = 'WEAPON_TECPISTOL',
+	["label"] = 'Tactical SMG',
+	},
+	[-1786099057] = {
+	["name"] = 'WEAPON_BAT',
+	["label"] = 'Bat',
+	},
+	[2138347493] = {
+	["name"] = 'WEAPON_FIREWORK',
+	["label"] = 'Firework Launcher',
+	},
+	[-1658906650] = {
+	["name"] = 'WEAPON_MILITARYRIFLE',
+	["label"] = 'Military Rifle',
+	},
+	[-656458692] = {
+	["name"] = 'WEAPON_KNUCKLE',
+	["label"] = 'Knuckle Dusters',
+	},
+	[126349499] = {
+	["name"] = 'WEAPON_SNOWBALL',
+	["label"] = 'Snow Ball',
+	},
+	[177293209] = {
+	["name"] = 'WEAPON_HEAVYSNIPER_MK2',
+	["label"] = 'Heavy Sniper MK2',
+	},
+	[-774507221] = {
+	["name"] = 'WEAPON_TACTICALRIFLE',
+	["label"] = 'Tactical Rifle',
+	},
+	[101631238] = {
+	["name"] = 'WEAPON_FIREEXTINGUISHER',
+	["label"] = 'Fire Extinguisher',
+	},
+	[-102323637] = {
+	["name"] = 'WEAPON_BOTTLE',
+	["label"] = 'Bottle',
+	},
+	[741814745] = {
+	["name"] = 'WEAPON_STICKYBOMB',
+	["label"] = 'Sticky Bomb',
+	},
+	[1672152130] = {
+	["name"] = 'WEAPON_HOMINGLAUNCHER',
+	["label"] = 'Homing Launcher',
+	},
+	[-1810795771] = {
+	["name"] = 'WEAPON_POOLCUE',
+	["label"] = 'Pool Cue',
+	},
+}
+
+
+return Weapon

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,658 @@
+                   GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    Ox Inventory
+    Copyright © 2023 Overextended (https://github.com/overextended)
+    Linden (https://github.com/thelindat)
+    Luke (https://github.com/LukeWasTakenn)
+    Dunak (https://github.com/dunak-debug)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# ox inventory meets weaponwheel
+
+# Big Update: Switching between hotbar and weaponwheel now controllable for users
+
+ox_inventory meets weaponwheel with hotbar controllable via exports for the user
+
+You can find an *updated* demo here: https://youtu.be/zZFSzWLmz_0
+
+I made some changes in the files that I provide here to have a weapon wheel, hotbar, or a combination of both controllable via exports. So you can implement them in your own commands or UI. 
+
+All changes I made are commentated and you can find them by searching for "Holger".
+Default state is weapon wheel enabled.
+# I don't provide an UI or commands to control these features only the exports
+
+Try to replace your files with the file I provide. If needed I can provide you my complete ox_inventory or provide support for implementing my files in your ox_inventory.
+
+There are 3 exports for handling the Hotbar, Weaponwheel, the combination of both and the weapon sync.
+
+exports["ox_inventory"]:weaponWheel()                Switch between hotbar and weapon wheel
+
+exports["ox_inventory"]:Weaponsyncdisable()          Disable weaponsync, so you can use temporary weapons that are not in your inventory (for FFA, Gangwar or stuff like this)
+
+exports["ox_inventory"]:WeaponWheelandHotbar()       Switch between hotbar and the combination of both
+
+When you have the combination of weapon wheel an hotbar enabled the keys 1 till 5 will control the hotbar, 6 till 9 and the mouse wheel will control the weapon wheel. Using Tab will trigger both standard functions of hotbar and weapon wheel. So the hotbar UI is visible and the weapon wheel is displayed or the weapon is changed. 
+
+
+# Example:
+
+exports["ox_inventory"]:weaponWheel(true)
+
+to enable the weapon wheel
+
+exports["ox_inventory"]:weaponWheel(false)
+
+to enable the hotbar after you had the weapon wheel enabled 
+
+exports["ox_inventory"]:Weaponsyncdisable(true)
+
+to deactivate the weaponsync (e.g. FFA)
+
+exports["ox_inventory"]:WeaponWheelandHotbar(true)
+
+to enable the combination of hotbar and weapon wheel
+
+exports["ox_inventory"]:WeaponWheelandHotbar(false)
+
+to enable the hotbar after enabling the weapon wheel or the combination of both
+
+# Happy for suggestions, improvements and found bugs :)
+
+Tested with version 2.42.3
+
+Compatibility with 2.43.3 is new and I'm not able to test it with a larger player base, please let me know if there are problems.
+
+All love and appreciation goes to overextended, they are making the best inventory for FiveM out there!
+
+Thanks for the inspiration and help goes to 5Labs https://github.com/5LABS

--- a/example_weaponwheel/fxmanifest.lua
+++ b/example_weaponwheel/fxmanifest.lua
@@ -1,0 +1,4 @@
+fx_version "adamant"
+game "gta5"
+
+client_script 'script.lua'

--- a/example_weaponwheel/script.lua
+++ b/example_weaponwheel/script.lua
@@ -1,0 +1,3 @@
+exports["ox_inventory"]:WeaponWheelandHotbar(true)
+exports["ox_inventory"]:weaponWheel(true)
+exports["ox_inventory"]:Weaponsyncdisable(true)

--- a/oxconfig.cfg
+++ b/oxconfig.cfg
@@ -1,0 +1,131 @@
+# Convars OX
+
+##OX Inventory
+
+setr ox:locale de
+
+### Shared
+ 
+# Activate specific event handlers and functions (supported: ox, esx, qb, nd)
+setr inventory:framework "esx"
+ 
+# Number of slots for player inventories
+setr inventory:slots 20
+ 
+# Maximum carry capacity for players, in grams (frameworks may override this)
+setr inventory:weight 50000
+ 
+# Integrated support for qtarget/ox_target stashes, shops, etc
+# Note: qtarget is deprecated, a future update may drop support (ox_target only, or gated features)
+setr inventory:target false
+ 
+# Jobs with access to police armoury, evidence lockers, etc
+setr inventory:police ["police", "sheriff"]
+ 
+### Client
+ 
+# The URL to load item images from
+setr inventory:imagepath "nui://ox_inventory/web/images"
+ 
+# Weapons will reload after reaching 0 ammo
+setr inventory:autoreload true
+ 
+# Blur the screen while accessing the inventory
+setr inventory:screenblur true
+ 
+# Default hotkeys to access primary and secondary inventories, and hotbar
+setr inventory:keys ["F2", "M", "TAB"]
+ 
+# Enable control action when inventory is open
+setr inventory:enablekeys [249]
+ 
+# Weapons must be aimed before shooting
+setr inventory:aimedfiring false
+ 
+# Show a list of all nearby players when giving items
+setr inventory:giveplayerlist true
+ 
+# Toggle weapon draw/holster animations
+setr inventory:weaponanims true
+ 
+# Toggle item notifications (add/remove)
+setr inventory:itemnotify true
+ 
+# Disable drop markers and spawn a prop instead
+setr inventory:dropprops true
+ 
+# Set the default model used for drop props
+setr inventory:dropmodel "prop_big_bag_01"
+ 
+# Disarm the player if an unexpected weapon is in use (i.e. did not use the weapon item)
+setr inventory:weaponmismatch false
+ 
+# Ignore weapon mismatch checks for the given weapon type (e.g. ['WEAPON_SHOVEL', 'WEAPON_HANDCUFFS'])
+setr inventory:ignoreweapons []
+ 
+# Suppress weapon and ammo pickups
+setr inventory:suppresspickups 1
+ 
+### Server
+ 
+# Compare current version to latest release on GitHub
+set inventory:versioncheck true
+ 
+# Stashes will be wiped after remaining unchanged for the given time
+set inventory:clearstashes "6 MONTH"
+ 
+# Discord webhook url, used for imageurl metadata content moderation (image embeds)
+set inventory:webhook ""
+ 
+# Logging via ox_lib (0: Disable, 1: Standard, 2: Include AddItem/RemoveItem, and all shop purchases)
+set inventory:loglevel 2
+ 
+# Item prices fluctuate in shops
+set inventory:randomprices true
+ 
+# Loot will randomly generate inside unowned vehicles and dumpsters
+set inventory:randomloot false
+ 
+# Minimum job grade to remove items from evidence lockers
+set inventory:evidencegrade 2
+ 
+# Trim whitespace from vehicle plates when checking owned vehicles
+setr inventory:trimplate true
+ 
+# Set the contents of randomly generated inventories
+# [item name, minimum, maximum, loot chance]
+set inventory:vehicleloot [
+    ["cola", 1, 1],
+    ["water", 1, 1],
+    ["garbage", 1, 2, 50],
+    ["panties", 1, 1, 5],
+    ##["money", 1, 50],
+    ##["money", 200, 400, 5],
+    ["bandage", 1, 1]
+]
+ 
+##set inventory:dumpsterloot [
+##    ["mustard", 1, 1],
+##    ["garbage", 1, 3],
+##    ["money", 1, 10],
+##    ["burger", 1, 1]
+##]
+ 
+# Set items to sync with framework accounts
+set inventory:accounts ["money","black_money"]
+
+
+# OXmysql config
+set mysql_slow_query_warning 200
+
+# Ox_lib
+
+add_ace resource.ox_lib command.add_ace allow
+add_ace resource.ox_lib command.remove_ace allow
+add_ace resource.ox_lib command.add_principal allow
+add_ace resource.ox_lib command.remove_principal allow
+
+setr ox:primaryColor violet
+setr ox:primaryShade 8
+
+# convars OX Ende


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Update patch files to latest ox_inventory (c4dfba5)</h1>
<h2>Summary</h2>
<p>Ports all of Holger's weapon wheel / hotbar / weaponsync modifications forward from <code>2.43.3</code> to the current HEAD of <a href="https://github.com/overextended/ox_inventory">overextended/ox_inventory</a> (commit <code>c4dfba5</code>, 2025-05-15).</p>
<hr>
<h2>Files changed</h2>

File | Status
-- | --
latest/client.lua | Added
latest/modules/utils/client.lua | Added
latest/modules/weapon/client.lua | Added


<hr>
<h2>What changed in upstream since 2.43.3</h2>
<p>The following upstream changes required careful merging to preserve Holger's modifications:</p>
<h3><code>client.lua</code></h3>
<ul>
<li><strong><code>useSlot</code></strong> — upstream refactored the weapon equip block; the <code>EnableWeaponWheel</code> early-return was restructured. Holger's dual-branch logic (weapon wheel mode vs hotbar mode, with the <code>dings</code> parameter for disarm behaviour) has been re-applied around the new structure.</li>
<li><strong><code>canSteal</code> check</strong> — upstream replaced the <code>shared.police</code> group guard with <code>Player(serverId).state.canSteal</code>; merged correctly alongside Holger's unchanged code in that region.</li>
<li><strong><code>client.closeInventory()</code></strong> — upstream dropped the <code>server</code> parameter; <code>currentInventory</code> now resets to <code>defaultInventory</code> instead of <code>nil</code>. Holger's code in this area had no conflict.</li>
<li><strong><code>Inventory.Dumpsters</code></strong> — upstream changed from <code>Inventory.Dumpsters[model]</code> (table lookup) to <code>Inventory.Dumpsters:includes(model)</code> (method call); carried through correctly.</li>
<li><strong><code>TriggerScreenblurFadeIn/Out</code></strong> calls replaced with <code>Utils.blurIn()</code> / <code>Utils.blurOut()</code> helpers; no conflict with Holger's code.</li>
<li><strong><code>RegisterCommand('steal', ...)</code></strong> now wrapped in an <code>if client.enablestealcommand then</code> guard; no conflict.</li>
<li><strong><code>OpenInventory</code> class annotation</strong> added by upstream; no conflict.</li>
</ul>
<h3><code>modules/utils/client.lua</code></h3>
<ul>
<li><strong><code>Utils.WeaponWheel()</code></strong> — upstream added an <code>override</code> parameter and a <code>weaponWheelOverride</code> local guard so vehicle/minigame overrides can't be cleared by normal callers. The existing <code>weaponWheel</code> export now wraps the function with <code>override = true</code>. Holger's <code>WeaponWheelsyncen()</code> calls <code>Utils.WeaponWheel()</code> without override, which is the correct behaviour — it will properly defer to any active override.</li>
<li><strong><code>suppressItemNotifications</code></strong> — new upstream feature (net event + export) for suppressing item pickup notifications; no conflict with Holger's additions.</li>
<li><strong><code>Utils.blurIn()</code> / <code>Utils.blurOut()</code></strong> — new upstream helpers wrapping screenblur with fade cancellation; added by upstream, no conflict.</li>
<li><strong><code>Utils.getPlayerName()</code> / <code>setGetPlayerNameMethod</code></strong> — new upstream export for customising player name display; no conflict.</li>
<li><strong><code>DrawMarker</code></strong> call in point rendering — upstream changed hardcoded values to <code>point.marker.type</code>, <code>point.marker.scale</code>, <code>point.marker.colour</code>; carried through correctly.</li>
<li>Holger's three exports (<code>Weaponsyncdisable</code>, <code>WeaponWheelandHotbar</code>, <code>weaponWheel</code>) all preserved.</li>
</ul>
<h3><code>modules/weapon/client.lua</code></h3>
<ul>
<li><strong><code>Weapon.Disarm()</code></strong> — upstream added no significant logic changes to the core of this function; Holger's <code>waffenlos</code> parameter, disabled <code>SetPedAmmo</code>, disabled <code>Utils.WeaponWheel()</code> + <code>RemoveAllPedWeapons</code> block, and conditional <code>GiveWeaponToPed</code> are all preserved. The commented-out block <code>--[[ ... end ]]</code> correctly wraps the three upstream lines that Holger disables.</li>
<li><strong><code>Weapon.Equip()</code></strong> — upstream made no structural changes; Holger's fist weapon give (<code>-1569615261</code>) before the equip animation is preserved.</li>
<li>Holger's <code>Weapon.triggerAnimation()</code> and <code>Weapon.WeaponByHash</code> table are carried forward unchanged.</li>
</ul>
<hr>
<h2>How to use</h2>
<ol>
<li>Clone or pull the latest <a href="https://github.com/overextended/ox_inventory">overextended/ox_inventory</a>.</li>
<li>Copy the three files from <code>latest/</code> into your ox_inventory folder, preserving the directory structure:
<pre><code>ox_inventory/├── client.lua                        ← replace├── modules/│   ├── utils/│   │   └── client.lua                ← replace│   └── weapon/│       └── client.lua                ← replace
</code></pre></li>
<li>The exports are unchanged from previous versions:
<pre><code class="language-lua">exports["ox_inventory"]:weaponWheel(true)          -- enable weapon wheelexports["ox_inventory"]:weaponWheel(false)          -- enable hotbarexports["ox_inventory"]:Weaponsyncdisable(true)     -- disable weapon sync (FFA etc.)exports["ox_inventory"]:WeaponWheelandHotbar(true)  -- enable combo modeexports["ox_inventory"]:WeaponWheelandHotbar(false) -- back to hotbar only
</code></pre></li>
</ol>
<hr>
<h2>Notes</h2>
<ul>
<li>All Holger modifications are marked with <code>--Holger</code> / <code>--Holgers Anpassungen</code> comments throughout, as in previous versions — searching for <code>Holger</code> will locate every change.</li>
<li>Tested against ox_inventory commit <code>c4dfba531e9d230c3b94d71ae4086c3f9789ef2a</code> (2025-05-15). If upstream moves significantly again, the three diff regions to watch are <code>useSlot</code> in <code>client.lua</code>, <code>Utils.WeaponWheel</code> in <code>modules/utils/client.lua</code>, and <code>Weapon.Disarm</code> in <code>modules/weapon/client.lua</code>.</li>
<li>The <code>oxconfig.cfg</code> is unchanged from the previous release.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>