### PR TITLE
Update to 2.47.0 and Example Script

### DIFF
--- a/2.47.0/client.lua
+++ b/2.47.0/client.lua
@@ -1,0 +1,2012 @@
+if not lib then return end
+
+require 'modules.bridge.client'
+require 'modules.interface.client'
+
+local Utils = require 'modules.utils.client'
+local Weapon = require 'modules.weapon.client'
+local currentWeapon
+
+--Holgers Anpassungen
+HotbarundWeaponWheel = false
+EnableWeaponWheel = true
+Waffencache = {}
+--Holgers Anpassungen bis hier
+
+exports('getCurrentWeapon', function()
+	return currentWeapon
+end)
+
+RegisterNetEvent('ox_inventory:disarm', function(noAnim)
+	currentWeapon = Weapon.Disarm(currentWeapon, noAnim)
+end)
+
+RegisterNetEvent('ox_inventory:clearWeapons', function()
+	Weapon.ClearAll(currentWeapon)
+end)
+
+local StashTarget
+
+exports('setStashTarget', function(id, owner)
+	StashTarget = id and {id=id, owner=owner}
+end)
+
+---@type boolean | number
+local invBusy = true
+
+---@type boolean?
+local invOpen = false
+local plyState = LocalPlayer.state
+local IsPedCuffed = IsPedCuffed
+local playerPed = cache.ped
+
+lib.onCache('ped', function(ped)
+	playerPed = ped
+	Utils.WeaponWheel()
+end)
+
+plyState:set('invBusy', true, true)
+plyState:set('invHotkeys', false, false)
+plyState:set('canUseWeapons', false, false)
+
+local function canOpenInventory()
+    if not PlayerData.loaded then
+        return shared.info('cannot open inventory', '(player inventory has not loaded)')
+    end
+
+    if IsPauseMenuActive() then return end
+
+    if invBusy or invOpen == nil or (currentWeapon?.timer or 0) > 0 then
+        return shared.info('cannot open inventory', '(is busy)')
+    end
+
+    if PlayerData.dead or IsPedFatallyInjured(playerPed) then
+        return shared.info('cannot open inventory', '(fatal injury)')
+    end
+
+    if PlayerData.cuffed or IsPedCuffed(playerPed) then
+        return shared.info('cannot open inventory', '(cuffed)')
+    end
+
+    return true
+end
+
+---@param ped number
+---@return boolean
+local function canOpenTarget(ped)
+	return IsPedFatallyInjured(ped)
+	or IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3)
+	or IsPedCuffed(ped)
+	or IsEntityPlayingAnim(ped, 'mp_arresting', 'idle', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_enter', 3)
+	or IsEntityPlayingAnim(ped, 'random@mugging3', 'handsup_standing_base', 3)
+end
+
+---@class OpenInventory
+---@field id string | integer
+---@field label string
+---@field type string
+---@field slots integer
+---@field weight integer
+---@field maxWeight integer
+---@field coords? vector3
+---@field distance? integer
+---@field instance? string | number
+---@field [string] unknown
+local defaultInventory = {
+	type = 'newdrop',
+	slots = shared.dropslots,
+	weight = 0,
+	maxWeight = shared.dropweight,
+	items = {}
+}
+
+local currentInventory = defaultInventory
+
+local function closeTrunk()
+	if currentInventory.type == 'trunk' then
+		local coords = GetEntityCoords(playerPed, true)
+		---@todo animation for vans?
+		Utils.PlayAnimAdvanced(0, 'anim@heists@fleeca_bank@scope_out@return_case', 'trevor_action', coords.x, coords.y, coords.z, 0.0, 0.0, GetEntityHeading(playerPed), 2.0, 2.0, 1000, 49, 0.25)
+
+		CreateThread(function()
+			local entity = currentInventory.entity
+			local door = currentInventory.door
+			Wait(900)
+
+			if type(door) == 'table' then
+				for i = 1, #door do
+					SetVehicleDoorShut(entity, door[i], false)
+				end
+			else
+				SetVehicleDoorShut(entity, door, false)
+			end
+		end)
+	end
+end
+
+local CraftingBenches = require 'modules.crafting.client'
+local Vehicles = lib.load('data.vehicles')
+local Inventory = require 'modules.inventory.client'
+
+---@param inv string?
+---@param data any?
+---@return boolean?
+function client.openInventory(inv, data)
+	if invOpen then
+		if not inv and currentInventory.type == 'newdrop' then
+			return client.closeInventory()
+		end
+
+		if IsNuiFocused() then
+			if inv == 'container' and currentInventory.id == PlayerData.inventory[data].metadata.container then
+				return client.closeInventory()
+			end
+
+			if currentInventory.type == 'drop' and (not data or currentInventory.id == (type(data) == 'table' and data.id or data)) then
+				return client.closeInventory()
+			end
+
+			if inv ~= 'drop' and inv ~= 'container' then
+				if (data?.id or data) == currentInventory.id then
+					-- Triggering exports.ox_inventory:openInventory('stash', 'mystash') twice in rapid succession is weird behaviour
+					return warn(("script tried to open inventory, but it is already open\n%s"):format(Citizen.InvokeNative(`FORMAT_STACK_TRACE` & 0xFFFFFFFF, nil, 0, Citizen.ResultAsString())))
+				else
+					return client.closeInventory()
+				end
+			end
+		end
+	elseif IsNuiFocused() then
+		-- If triggering from another nui, may need to wait for focus to end.
+		Wait(100)
+
+        -- People still complain about this being an "error" and ask "how fix" despite being a warning
+        -- for people with above room-temperature iqs to look into resource conflicts on their own.
+		-- if IsNuiFocused() then
+		-- 	warn('other scripts have nui focus and may cause issues (e.g. disable focus, prevent input, overlap inventory window)')
+		-- end
+	end
+
+	if inv == 'dumpster' and cache.vehicle then
+		return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+	end
+
+	if not canOpenInventory() then
+        return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+    end
+
+    local left, right, accessError
+
+    if inv == 'player' and data ~= cache.serverId then
+        local targetId, targetPed, serverId
+
+        if not data then
+            targetId, targetPed = Utils.GetClosestPlayer()
+            serverId = targetId and GetPlayerServerId(targetId)
+            data = serverId
+        else
+            serverId = type(data) == 'table' and data.id or data
+            targetId = serverId and GetPlayerFromServerId(serverId)
+            targetPed = targetId and GetPlayerPed(targetId)
+        end
+
+        if serverId == cache.serverId then return end
+
+        local targetCoords = targetPed and GetEntityCoords(targetPed)
+
+        if not targetCoords or #(targetCoords - GetEntityCoords(playerPed)) > 1.8 or (not client.hasGroup(shared.police) and not Player(serverId).state.canSteal) then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+    end
+
+    if inv == 'shop' and invOpen == false then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
+    elseif inv == 'crafting' then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+
+        if left then
+            right = CraftingBenches[data.id]
+
+            if not right?.items then return end
+
+            local coords, distance
+
+            if not right.zones and not right.points then
+                coords = GetEntityCoords(cache.ped)
+                distance = 2
+            else
+                coords = shared.target and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+                distance = coords and shared.target and right.zones[data.index].distance or 2
+            end
+
+            right = {
+                type = 'crafting',
+                id = data.id,
+                label = right.label or locale('crafting_bench'),
+                index = data.index,
+                slots = right.slots,
+                items = right.items,
+                coords = coords,
+                distance = distance
+            }
+        end
+    elseif invOpen ~= nil then
+        if inv == 'policeevidence' then
+            if not data then
+                local input = lib.inputDialog(locale('police_evidence'), {
+                    { label = locale('locker_number'), type = 'number', required = true, icon = 'calculator' }
+                }) --[[@as number[]? ]]
+
+                if not input then return end
+
+                data = input[1]
+            end
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+    end
+
+    if accessError then
+        return lib.notify({ id = accessError, type = 'error', description = locale(accessError) })
+    end
+
+    -- Stash does not exist
+    if not left then
+        if left == false then return false end
+
+        if invOpen == false then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+
+        if invOpen then return client.closeInventory() end
+    end
+
+
+    if not cache.vehicle then
+        if inv == 'player' then
+            Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+        elseif inv ~= 'trunk' then
+            Utils.PlayAnim(0, 'pickup_object', 'putdown_low', 5.0, 1.5, 1000, 48, 0.0, 0, 0, 0)
+        end
+    end
+
+    plyState.invOpen = true
+
+    SetInterval(client.interval, 100)
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+    closeTrunk()
+
+    if client.screenblur then Utils.blurIn() end
+
+    currentInventory = right or defaultInventory
+    left.items = PlayerData.inventory
+    left.groups = PlayerData.groups
+
+    SendNUIMessage({
+        action = 'setupInventory',
+        data = {
+            leftInventory = left,
+            rightInventory = currentInventory
+        }
+    })
+
+    if inv and not currentInventory.coords and inv ~= 'container' and inv ~= 'glovebox' then
+        currentInventory.coords = GetEntityCoords(playerPed)
+    end
+
+    if inv == 'trunk' then
+        SetTimeout(200, function()
+            ---@todo animation for vans?
+            Utils.PlayAnim(0, 'anim@heists@prison_heiststation@cop_reactions', 'cop_b_idle', 3.0, 3.0, -1, 49, 0.0, 0, 0, 0)
+
+            local entity = data.entity or NetworkGetEntityFromNetworkId(data.netid)
+            currentInventory.entity = entity
+            currentInventory.door = data.door
+
+            if not currentInventory.door then
+                local vehicleHash = GetEntityModel(entity)
+                local vehicleClass = GetVehicleClass(entity)
+                currentInventory.door = vehicleClass == 12 and { 2, 3 } or Vehicles.Storage[vehicleHash] and 4 or 5
+            end
+
+            while currentInventory.entity == entity and invOpen and DoesEntityExist(entity) and Inventory.CanAccessTrunk(entity) do
+                Wait(100)
+            end
+
+            if invOpen then client.closeInventory() end
+        end)
+    end
+
+    return true
+end
+
+RegisterNetEvent('ox_inventory:openInventory', client.openInventory)
+exports('openInventory', client.openInventory)
+
+RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+local Animations = lib.load('data.animations')
+local Items = require 'modules.items.client'
+local usingItem = false
+
+---@param data { name: string, label: string, count: number, slot: number, metadata: table<string, any>, weight: number }
+lib.callback.register('ox_inventory:usingItem', function(data, noAnim)
+	local item = Items[data.name]
+
+	if item and usingItem then
+		if not item.client then return true end
+		---@cast item +OxClientProps
+		item = item.client
+
+		if type(item.anim) == 'string' then
+			item.anim = Animations.anim[item.anim]
+		end
+
+		if item.prop then
+			if item.prop[1] then
+				for i = 1, #item.prop do
+					if type(item.prop) == 'string' then
+						item.prop = Animations.prop[item.prop[i]]
+					end
+				end
+			elseif type(item.prop) == 'string' then
+				item.prop = Animations.prop[item.prop]
+			end
+		end
+
+		if not item.disable then
+			item.disable = { combat = true }
+		elseif item.disable.combat == nil then
+			-- Backwards compatibility; you probably don't want people shooting while eating and bandaging anyway
+			item.disable.combat = true
+		end
+
+		local success = (not item.usetime or noAnim or lib.progressBar({
+			duration = item.usetime,
+			label = item.label or locale('using', data.metadata.label or data.label),
+			useWhileDead = item.useWhileDead,
+			canCancel = item.cancel,
+			disable = item.disable,
+			anim = item.anim or item.scenario,
+			prop = item.prop --[[@as ProgressProps]]
+		})) and not PlayerData.dead
+
+		if success then
+			if item.notification then
+				lib.notify({ description = item.notification })
+			end
+
+			if item.status then
+				if client.setPlayerStatus then
+					client.setPlayerStatus(item.status)
+				end
+			end
+
+			return true
+		end
+	end
+end)
+
+local function canUseItem(isAmmo)
+	local ped = cache.ped
+
+	return not usingItem
+    and (not isAmmo or currentWeapon)
+	and PlayerData.loaded
+	and not PlayerData.dead
+	and not invBusy
+	and not lib.progressActive()
+	and not IsPedRagdoll(ped)
+	and not IsPedFalling(ped)
+    and not IsPedShooting(playerPed)
+end
+
+---@param data table
+---@param cb fun(response: SlotWithItem | false)?
+---@param noAnim? boolean
+local function useItem(data, cb, noAnim)
+	local slotData, result = PlayerData.inventory[data.slot]
+
+	if not slotData or not canUseItem(data.ammo and true) then
+        if currentWeapon then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        return
+    end
+
+	if currentWeapon and currentWeapon.timer ~= 0 then
+        if not currentWeapon.timer or currentWeapon.timer - GetGameTimer() > 100 then return end
+
+        DisablePlayerFiring(cache.playerId, true)
+    end
+
+    if invOpen and data.close then client.closeInventory() end
+
+    usingItem = true
+    ---@type boolean?
+    result = lib.callback.await('ox_inventory:useItem', 200, data.name, data.slot, slotData.metadata, noAnim)
+
+	if result and cb then
+		local success, response = pcall(cb, result and slotData)
+
+		if not success and response then
+			warn(('^1An error occurred while calling item "%s" callback!\n^1SCRIPT ERROR: %s^0'):format(slotData.name, response))
+		end
+	end
+
+    if result then
+        TriggerEvent('ox_inventory:usedItem', slotData.name, slotData.slot, next(slotData.metadata) and slotData.metadata)
+    end
+
+	Wait(500)
+    usingItem = false
+end
+
+AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+end)
+
+AddEventHandler('ox_inventory:item', useItem)
+exports('useItem', useItem)
+
+---@param slot number
+---@return boolean?
+local function useSlot(slot, noAnim, dings) --dings added by Holger
+	local item = PlayerData.inventory[slot]
+	if not item then return end
+
+	local data = Items[item.name]
+	if not data then return end
+
+	if canUseItem(data.ammo and true) then
+		if data.component and not currentWeapon then
+			return lib.notify({ id = 'weapon_hand_required', type = 'error', description = locale('weapon_hand_required') })
+		end
+
+		local durability = item.metadata.durability --[[@as number?]]
+		local consume = data.consume --[[@as number?]]
+		local label = item.metadata.label or item.label --[[@as string]]
+
+		-- Naive durability check to get an early exit
+		-- People often don't call the 'useItem' export and then complain about "broken" items being usable
+		-- This won't work with degradation since we need access to os.time on the server
+		if durability and durability <= 100 and consume then
+			if durability <= 0 then
+				return lib.notify({ type = 'error', description = locale('no_durability', label) })
+			elseif consume ~= 0 and consume < 1 and durability < consume * 100 then
+				return lib.notify({ type = 'error', description = locale('not_enough_durability', label) })
+			end
+		end
+
+		data.slot = slot
+
+		if item.metadata.container then
+			return client.openInventory('container', item.slot)
+		elseif data.client then
+			if invOpen and data.close then client.closeInventory() end
+
+			if data.export then
+				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
+				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			end
+		end
+
+		if data.effect then
+			data:effect({name = item.name, slot = item.slot, metadata = item.metadata})
+		elseif data.weapon then
+			if not plyState.canUseWeapons then return end
+			if EnableWeaponWheel then -- if by Holger
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+
+					if dings then -- if by Holger
+						currentWeapon =  Weapon.Disarm(currentWeapon,false,true)
+					else					
+						currentWeapon =  Weapon.Disarm(currentWeapon)
+					end
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			else
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+					
+					currentWeapon =  Weapon.Disarm(currentWeapon)
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			end
+		elseif currentWeapon then
+			if data.ammo then
+				if Utils.Waffensyncaus or currentWeapon.metadata.durability <= 0 then return end ----Holger replaced : EnableWeaponWheel to Utils.Waffensyncaus
+
+				local clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+				local currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+				local _, maxAmmo = GetMaxAmmo(playerPed, currentWeapon.hash)
+
+				if maxAmmo < clipSize then clipSize = maxAmmo end
+
+				if currentAmmo == clipSize then return end
+
+				useItem(data, function(resp)
+					if not resp or resp.name ~= currentWeapon?.ammo then return end
+
+					if currentWeapon.metadata.specialAmmo ~= resp.metadata.type and type(currentWeapon.metadata.specialAmmo) == 'string' then
+						local clipComponentKey = ('%s_CLIP'):format(Items[currentWeapon.name].model:gsub('WEAPON_', 'COMPONENT_'))
+						local specialClip = ('%s_%s'):format(clipComponentKey, (resp.metadata.type or currentWeapon.metadata.specialAmmo):upper())
+
+						if type(resp.metadata.type) == 'string' then
+							if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+								if not DoesWeaponTakeWeaponComponent(currentWeapon.hash, specialClip) then
+									warn('cannot use clip with this weapon')
+									return
+								end
+
+								local defaultClip = ('%s_01'):format(clipComponentKey)
+
+								if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, defaultClip) then
+									warn('cannot use clip with currently equipped clip')
+									return
+								end
+
+								if currentAmmo > 0 then
+									warn('cannot mix special ammo with base ammo')
+									return
+								end
+
+								currentWeapon.metadata.specialAmmo = resp.metadata.type
+
+								GiveWeaponComponentToPed(playerPed, currentWeapon.hash, specialClip)
+							end
+						elseif HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+							if currentAmmo > 0 then
+								warn('cannot mix special ammo with base ammo')
+								return
+							end
+
+							currentWeapon.metadata.specialAmmo = nil
+
+							RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, specialClip)
+						end
+					end
+
+					if maxAmmo > clipSize then
+						clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+					end
+
+					currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+					local missingAmmo = clipSize - currentAmmo
+					local addAmmo = resp.count > missingAmmo and missingAmmo or resp.count
+					local newAmmo = currentAmmo + addAmmo
+
+					if newAmmo == currentAmmo then return end
+
+                    AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
+
+					if cache.vehicle then
+						if cache.seat > -1 or IsVehicleStopped(cache.vehicle) then
+							TaskReloadWeapon(playerPed, true)
+                        else
+                            -- This is a hacky solution for forcing ammo to properly load into the
+                            -- weapon clip while driving; without it, ammo will be added but won't
+                            -- load until the player stops doing anything. i.e. if you keep shooting,
+                            -- the weapon will not reload until the clip empties.
+                            -- And yes - for some reason RefillAmmoInstantly needs to run in a loop.
+                            lib.waitFor(function()
+                                RefillAmmoInstantly(playerPed)
+
+                                local _, ammo = GetAmmoInClip(playerPed, currentWeapon.hash)
+                                return ammo == newAmmo or nil
+                            end)
+                        end
+					else
+						Wait(100)
+						MakePedReload(playerPed)
+
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
+					end
+
+					lib.callback.await('ox_inventory:updateWeapon', false, 'load', newAmmo, false, currentWeapon.metadata.specialAmmo)
+				end)
+			elseif data.component then
+				local components = data.client.component
+
+                if not components then return end
+
+				local componentType = data.type
+				local weaponComponents = PlayerData.inventory[currentWeapon.slot].metadata.components
+
+				-- Checks if the weapon already has the same component type attached
+				for componentIndex = 1, #weaponComponents do
+					if componentType == Items[weaponComponents[componentIndex]].type then
+						return lib.notify({ id = 'component_slot_occupied', type = 'error', description = locale('component_slot_occupied', componentType) })
+					end
+				end
+
+				for i = 1, #components do
+					local component = components[i]
+
+					if DoesWeaponTakeWeaponComponent(currentWeapon.hash, component) then
+						if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+							lib.notify({ id = 'component_has', type = 'error', description = locale('component_has', label) })
+						else
+							useItem(data, function(data)
+								if data then
+									local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', tostring(data.slot), currentWeapon.slot)
+
+									if success then
+										GiveWeaponComponentToPed(playerPed, currentWeapon.hash, component)
+										TriggerEvent('ox_inventory:updateWeaponComponent', 'added', component, data.name)
+									end
+								end
+							end)
+						end
+						return
+					end
+				end
+				lib.notify({ id = 'component_invalid', type = 'error', description = locale('component_invalid', label) })
+			elseif data.allowArmed then
+				useItem(data)
+            else
+                return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+			end
+		elseif not data.ammo and not data.component then
+			useItem(data)
+		end
+    end
+end
+exports('useSlot', useSlot)
+
+---@param id number
+---@param slot number
+local function useButton(id, slot)
+	if PlayerData.loaded and not invBusy and not lib.progressActive() then
+		local item = PlayerData.inventory[slot]
+		if not item then return end
+
+		local data = Items[item.name]
+		local buttons = data?.buttons
+
+		if buttons and buttons[id]?.action then
+			buttons[id].action(slot)
+		end
+	end
+end
+
+local function openNearbyInventory() client.openInventory('player') end
+
+exports('openNearbyInventory', openNearbyInventory)
+
+local currentInstance
+local playerCoords
+local Shops = require 'modules.shops.client'
+
+---@todo remove or replace when the bridge module gets restructured
+function OnPlayerData(key, val)
+	if key ~= 'groups' and key ~= 'ped' and key ~= 'dead' then return end
+
+	if key == 'groups' then
+		Inventory.Stashes()
+		Inventory.Evidence()
+		Shops.refreshShops()
+	elseif key == 'dead' and val then
+		currentWeapon = Weapon.Disarm(currentWeapon)
+		client.closeInventory()
+	end
+
+	Utils.WeaponWheel()
+end
+
+-- People consistently ignore errors when one of the "modules" failed to load
+if not Utils or not Weapon or not Items or not Inventory then return end
+
+local invHotkeys = false
+
+---@type function?
+local function registerCommands()
+	if client.enablestealcommand then
+		RegisterCommand('steal', openNearbyInventory, false)
+	end
+
+	local function openGlovebox(vehicle)
+		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end
+
+		if IsEntityDead(vehicle) then return end
+
+		local vehicleHash = GetEntityModel(vehicle)
+		local vehicleClass = GetVehicleClass(vehicle)
+		local checkVehicle = Vehicles.Storage[vehicleHash]
+
+		-- No storage or no glovebox
+		if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
+
+		local isOpen = client.openInventory('glovebox', { netid = NetworkGetNetworkIdFromEntity(vehicle) })
+
+		if isOpen then
+			currentInventory.entity = vehicle
+		end
+	end
+
+	local primary = lib.addKeybind({
+		name = 'inv',
+		description = locale('open_player_inventory'),
+		defaultKey = client.keys[1],
+		onPressed = function()
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local closest = lib.points.getClosestPoint()
+
+			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
+				if closest.inv == 'crafting' then
+					return client.openInventory('crafting', { id = closest.id, index = closest.index })
+				elseif closest.inv ~= 'license' and closest.inv ~= 'policeevidence' then
+					return client.openInventory(closest.inv or 'drop', { id = closest.invId, type = closest.type })
+				end
+			end
+
+			return client.openInventory()
+		end
+	})
+
+	lib.addKeybind({
+		name = 'inv2',
+		description = locale('open_secondary_inventory'),
+		defaultKey = client.keys[2],
+		onPressed = function(self)
+            if primary:getCurrentKey() == self:getCurrentKey() then
+                return warn(("secondary inventory keybind '%s' disabled (keybind cannot match primary inventory keybind)"):format(self:getCurrentKey()))
+            end
+
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if invBusy or not canOpenInventory() then
+				return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+			end
+
+			if StashTarget then
+				return client.openInventory('stash', StashTarget)
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local entity, entityType = Utils.Raycast(2|16)
+
+			if not entity then return end
+
+			if not shared.target and entityType == 3 then
+				local model = GetEntityModel(entity)
+
+				if Inventory.Dumpsters:includes(model) then
+					return Inventory.OpenDumpster(entity)
+				end
+			end
+
+			if entityType ~= 2 then return end
+
+			Inventory.OpenTrunk(entity)
+		end
+	})
+
+	lib.addKeybind({
+		name = 'reloadweapon',
+		description = locale('reload_weapon'),
+		defaultKey = 'r',
+		onPressed = function(self)
+			if not currentWeapon or Utils.Waffensyncaus or not canUseItem(true) then return end ---Holger changed EnableWeaponWheel to Utils.Waffensyncaus
+
+			if currentWeapon.ammo then
+				if currentWeapon.metadata.durability > 0 then
+					local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+					if slotId then
+						useSlot(slotId)
+					end
+				else
+					lib.notify({ id = 'no_durability', type = 'error', description = locale('no_durability', currentWeapon.label) })
+				end
+			end
+		end
+	})
+
+	lib.addKeybind({
+		name = 'hotbar',
+		description = locale('disable_hotbar'),
+		defaultKey = client.keys[3],
+		onPressed = function()
+			if (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() or lib.progressActive() then return end --Holger added: and not HotbarundWeaponWheel
+			SendNUIMessage({ action = 'toggleHotbar' })
+		end
+	})
+
+	for i = 1, 5 do
+		lib.addKeybind({
+			name = ('hotkey%s'):format(i),
+			description = locale('use_hotbar', i),
+			defaultKey = tostring(i),
+			onPressed = function()
+				if invOpen or (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() then return end --Holger added: and not HotbarundWeaponWheel
+				useSlot(i)
+			end
+		})
+	end
+
+	registerCommands = nil
+end
+
+function client.closeInventory()
+	if not client.interval then return end
+
+	if invOpen then
+		invOpen = nil
+		SetNuiFocus(false, false)
+		SetNuiFocusKeepInput(false)
+		Utils.blurOut()
+		closeTrunk()
+		SendNUIMessage({ action = 'closeInventory' })
+		SetInterval(client.interval, 200)
+		Wait(200)
+
+		if invOpen ~= nil then return end
+
+		TriggerServerEvent('ox_inventory:closeInventory')
+
+		currentInventory = defaultInventory
+		plyState.invOpen = false
+		defaultInventory.coords = nil
+	end
+end
+
+RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
+exports('closeInventory', client.closeInventory)
+
+---@param data updateSlot[]
+---@param weight number
+local function updateInventory(data, weight)
+	local changes = {}
+    ---@type table<string, number>
+	local itemCount = {}
+
+	for i = 1, #data do
+		local v = data[i]
+
+		if not v.inventory or v.inventory == cache.serverId then
+			v.inventory = 'player'
+			local item = v.item
+
+			if currentWeapon?.slot == item?.slot then
+                if item.metadata then
+				    currentWeapon.metadata = item.metadata
+				    TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
+                else
+                    currentWeapon = Weapon.Disarm(currentWeapon, true)
+                end
+			end
+
+			local curItem = PlayerData.inventory[item.slot]
+
+			if curItem and curItem.name then  -- if changed by Holger
+				if itemCount[curItem.name] == nil then
+					itemCount[curItem.name] = {}
+				end
+				itemCount[curItem.name].count = (itemCount[curItem.name].count or 0) - curItem.count
+				itemCount[curItem.name].slot = item.slot
+			end
+
+			if item.count then	-- if changed by Holger
+				if itemCount[item.name] == nil then
+					itemCount[item.name] = {}
+				end
+				itemCount[item.name].count = (itemCount[item.name].count or 0) + item.count
+				itemCount[item.name].slot = item.slot
+			end
+
+			changes[item.slot] = item.count and item or false
+			if not item.count then item.name = nil end
+			PlayerData.inventory[item.slot] = item.name and item or nil
+		end
+	end
+
+	SendNUIMessage({ action = 'refreshSlots', data = { items = data, itemCount = itemCount} })
+
+    if weight ~= PlayerData.weight then client.setPlayerData('weight', weight) end
+
+	for itemName, dings in pairs(itemCount) do --changed count to dings	Holger
+		local item = Items(itemName)
+
+        if item then
+            item.count += dings.count --added dings.	Holger
+
+			------------Holgers Anpassungen
+			if string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN"  and item.count  >0 and not HasPedGotWeapon(cache.ped,item.name,false) then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash] = {}
+				Waffencache[hash].name = item.name
+				Waffencache[hash].slot = dings.slot
+				Waffencache[hash].hash = hash
+				
+				RemoveWeaponFromPed(cache.ped,item.name)
+				GiveWeaponToPed(cache.ped,item.name,1,false,false) 
+			elseif string.sub(item.name,1,7) =="WEAPON_" and item.count  == 0 then
+				local loeschdas
+				for k,v in pairs(Waffencache) do
+					if v.name ==item.name then
+						loeschdas = k
+					end
+				end
+				Waffencache[loeschdas] = nil
+				if currentWeapon and currentWeapon.name == item.name then
+					currentWeapon = Weapon.Disarm(currentWeapon, false,"lurch")
+				else
+					RemoveWeaponFromPed(cache.ped,item.name)
+				end 
+			end
+
+			-----Holgers Anpassungen ende
+
+            TriggerEvent('ox_inventory:itemCount', item.name, item.count)
+
+            if dings.count < 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:removeInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.remove then
+                    item.client.remove(item.count)
+                end
+            elseif dings.count > 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:addInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.add then
+                    item.client.add(item.count)
+                end
+            end
+        end
+	end
+
+	client.setPlayerData('inventory', PlayerData.inventory)
+	TriggerEvent('ox_inventory:updateInventory', changes)
+end
+
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
+	if source ~= '' and next(items) then updateInventory(items, weights) end
+end)
+
+RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
+	if source == '' then return end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	lib.notify({ description = locale('items_returned') })
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for _, slotData in pairs(data[1]) do
+		num += 1
+		items[num] = { item = slotData, inventory = cache.serverId }
+	end
+
+	updateInventory(items, data[3])
+end)
+
+RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
+	if source == '' then return end
+	if message then lib.notify({ description = locale('items_confiscated') }) end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for slot in pairs(PlayerData.inventory) do
+		num += 1
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
+	end
+
+	updateInventory(items, 0)
+end)
+
+
+---@param point CPoint
+local function nearbyDrop(point)
+	if not point.instance or point.instance == currentInstance then
+        DrawMarker(client.dropmarker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, client.dropmarker.scale[1], client.dropmarker.scale[2], client.dropmarker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        client.dropmarker.colour[1], client.dropmarker.colour[2], client.dropmarker.colour[3], 222, false, false, 0, true, false, false, false)
+    end
+end
+
+---@param point CPoint
+local function onEnterDrop(point)
+	if not point.instance or point.instance == currentInstance and not point.entity then
+		local model = point.model or client.dropmodel
+
+        -- Prevent breaking inventory on invalid point.model instead use default client.dropmodel
+        if not IsModelValid(model) and not IsModelInCdimage(model) then
+            model = client.dropmodel
+        end
+		lib.requestModel(model)
+
+		local entity = CreateObject(model, point.coords.x, point.coords.y, point.coords.z, false, true, true)
+
+		SetModelAsNoLongerNeeded(model)
+		PlaceObjectOnGroundProperly(entity)
+		FreezeEntityPosition(entity, true)
+		SetEntityCollision(entity, false, true)
+
+		point.entity = entity
+	end
+end
+
+local function onExitDrop(point)
+	local entity = point.entity
+
+	if entity then
+		Utils.DeleteEntity(entity)
+		point.entity = nil
+	end
+end
+
+local function createDrop(dropId, data)
+	local point = lib.points.new({
+		coords = data.coords,
+		distance = 16,
+		invId = dropId,
+		instance = data.instance,
+		model = data.model
+	})
+
+	if point.model or client.dropprops then
+		point.distance = 30
+		point.onEnter = onEnterDrop
+		point.onExit = onExitDrop
+	else
+		point.nearby = nearbyDrop
+	end
+
+	client.drops[dropId] = point
+end
+
+RegisterNetEvent('ox_inventory:createDrop', function(dropId, data, owner, slot)
+	if client.drops then
+		createDrop(dropId, data)
+	end
+
+	if owner == cache.serverId then
+		if currentWeapon?.slot == slot then
+			currentWeapon = Weapon.Disarm(currentWeapon)
+		end
+
+		if invOpen and #(GetEntityCoords(playerPed) - data.coords) <= 1 then
+			if not cache.vehicle then
+				client.openInventory('drop', dropId)
+			else
+				SendNUIMessage({
+					action = 'setupInventory',
+					data = { rightInventory = currentInventory }
+				})
+			end
+		end
+	end
+end)
+
+RegisterNetEvent('ox_inventory:removeDrop', function(dropId)
+	if client.drops then
+		local point = client.drops[dropId]
+
+		if point then
+			client.drops[dropId] = nil
+			point:remove()
+
+			if point.entity then Utils.DeleteEntity(point.entity) end
+		end
+	end
+end)
+
+---@type function?
+local function setStateBagHandler(stateId)
+	AddStateBagChangeHandler('invOpen', stateId, function(_, _, value)
+		invOpen = value
+	end)
+
+	AddStateBagChangeHandler('invBusy', stateId, function(_, _, value)
+		invBusy = value
+	end)
+
+    AddStateBagChangeHandler('canUseWeapons', stateId, function(_, _, value)
+        if not value and currentWeapon then
+            currentWeapon = Weapon.Disarm(currentWeapon)
+        end
+    end)
+
+	AddStateBagChangeHandler('instance', stateId, function(_, _, value)
+		currentInstance = value
+
+		if client.drops then
+			-- Iterate over known drops and remove any points in a different instance (ignoring no instance)
+			for dropId, point in pairs(client.drops) do
+				if point.instance then
+					if point.instance ~= value then
+						if point.entity then
+							Utils.DeleteEntity(point.entity)
+							point.entity = nil
+						end
+
+						point:remove()
+					else
+						-- Recreate the drop using data from the old point
+						createDrop(dropId, point)
+					end
+				end
+			end
+		end
+	end)
+
+	AddStateBagChangeHandler('dead', stateId, function(_, _, value)
+		Utils.WeaponWheel()
+		PlayerData.dead = value
+	end)
+
+	AddStateBagChangeHandler('invHotkeys', stateId, function(_, _, value)
+		invHotkeys = value
+	end)
+
+	setStateBagHandler = nil
+end
+
+RegisterNetEvent('txcl:heal', function()
+    if source == '' then return end
+
+    PlayerData.dead = false
+end)
+
+lib.onCache('seat', function(seat)
+	if seat then
+		local hasWeapon = GetCurrentPedVehicleWeapon(cache.ped)
+
+		if hasWeapon then
+			return Utils.WeaponWheel(true)
+		end
+	end
+
+	Utils.WeaponWheel(false)
+end)
+
+lib.onCache('vehicle', function()
+	if invOpen and (not currentInventory.entity or currentInventory.entity == cache.vehicle) then
+		return client.closeInventory()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inventory, weight, player)
+	if source == '' then return end
+
+    ---@class PlayerData
+    ---@field inventory table<number, SlotWithItem?>
+    ---@field weight number
+    ---@field groups table<string, number>
+	PlayerData = player
+	PlayerData.id = cache.playerId
+	PlayerData.source = cache.serverId
+    PlayerData.maxWeight = shared.playerweight
+
+	setmetatable(PlayerData, {
+		__index = function(self, key)
+			if key == 'ped' then
+				return PlayerPedId()
+			end
+		end
+	})
+
+	if setStateBagHandler then setStateBagHandler(('player:%s'):format(cache.serverId)) end
+
+	local ItemData = table.create(0, #Items)
+
+	for _, v in pairs(Items --[[@as table<string, OxClientItem>]]) do
+		local buttons = v.buttons and {} or nil
+
+		if buttons then
+			for i = 1, #v.buttons do
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
+			end
+		end
+
+		ItemData[v.name] = {
+			label = v.label,
+			stack = v.stack,
+			close = v.close,
+			count = 0,
+			description = v.description,
+			buttons = buttons,
+			ammoName = v.ammoname,
+			image = v.client?.image
+		}
+	end
+
+	for _, data in pairs(inventory) do
+		local item = Items[data.name]
+
+		if item then
+			item.count += data.count
+			ItemData[data.name].count += data.count
+			local add = item.client?.add
+
+			if add then
+				add(item.count)
+			end
+		end
+	end
+
+	local phone = Items.phone
+
+	if phone and phone.count < 1 then
+		pcall(function()
+			return exports.npwd:setPhoneDisabled(true)
+		end)
+	end
+
+	client.setPlayerData('inventory', inventory)
+	client.setPlayerData('weight', weight)
+	currentWeapon = nil
+	Weapon.ClearAll()
+
+	local uiLocales = {}
+	local locales = lib.getLocales()
+
+	for k, v in pairs(locales) do
+		if k:find('^ui_')then
+			uiLocales[k] = v
+		end
+	end
+
+	uiLocales['$'] = locales['$']
+	uiLocales.ammo_type = locales.ammo_type
+
+	client.drops = currentDrops
+
+	for dropId, data in pairs(currentDrops) do
+		createDrop(dropId, data)
+	end
+
+	local hasTextUi
+	local uiOptions = { icon = 'fa-id-card' }
+
+	---@param point CPoint
+	local function nearbyLicense(point)
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, 0, true, false, false, false)
+
+		if point.isClosest and point.currentDistance < 1.2 then
+			if not hasTextUi then
+				hasTextUi = point
+				lib.showTextUI(point.message, uiOptions)
+			end
+
+			if IsControlJustReleased(0, 38) then
+				lib.callback('ox_inventory:buyLicense', 1000, function(success, message)
+					if success ~= nil then
+						lib.notify({
+							id = message,
+							type = success == false and 'error' or 'success',
+							description = locale(message, locale('license', point.type:gsub("^%l", string.upper)))
+						})
+					end
+				end, point.invId)
+			end
+		elseif hasTextUi == point then
+			hasTextUi = false
+			lib.hideTextUI()
+		end
+	end
+
+	for id, data in pairs(lib.load('data.licenses') or {}) do
+		lib.points.new({
+			coords = data.coords,
+			distance = 16,
+			inv = 'license',
+			type = data.name,
+			price = data.price,
+			invId = id,
+			nearby = nearbyLicense,
+			message = ('**%s**  \n%s'):format(locale('purchase_license', data.name), locale('interact_prompt', GetControlInstructionalButton(0, 38, true):sub(3)))
+		})
+	end
+
+	while not client.uiLoaded do Wait(50) end
+
+	SendNUIMessage({
+		action = 'init',
+		data = {
+			locale = uiLocales,
+			items = ItemData,
+			leftInventory = {
+				id = cache.playerId,
+				slots = shared.playerslots,
+				items = PlayerData.inventory,
+				maxWeight = shared.playerweight,
+			},
+			imagepath = client.imagepath
+		}
+	})
+
+	PlayerData.loaded = true
+
+	if not client.disablesetupnotification then
+		lib.notify({ description = locale('inventory_setup') })
+	end
+
+	Shops.refreshShops()
+	Inventory.Stashes()
+	Inventory.Evidence()
+
+	if registerCommands then registerCommands() end
+
+	TriggerEvent('ox_inventory:updateInventory', PlayerData.inventory)
+
+	client.interval = SetInterval(function()
+        local canSteal = canOpenTarget(playerPed)
+
+        if canSteal ~= plyState.canSteal then
+            plyState:set('canSteal', canSteal, true)
+        end
+
+		if invOpen == false then
+			playerCoords = GetEntityCoords(playerPed)
+
+			if currentWeapon and IsPedUsingActionMode(playerPed) then
+				SetPedUsingActionMode(playerPed, false, -1, 'DEFAULT_ACTION')
+			end
+
+		elseif invOpen == true then
+			if not canOpenInventory() then
+				client.closeInventory()
+			else
+				playerCoords = GetEntityCoords(playerPed)
+
+				if not currentInventory.ignoreSecurityChecks then
+                    local maxDistance = (currentInventory.distance or currentInventory.type == 'stash' and 4.8 or 1.8) + 0.2
+
+					if currentInventory.type == 'otherplayer' then
+						local id = GetPlayerFromServerId(currentInventory.id --[[@as number]])
+						local ped = GetPlayerPed(id)
+						local pedCoords = GetEntityCoords(ped)
+
+						if not id or #(playerCoords - pedCoords) > maxDistance or (not client.hasGroup(shared.police) and not Player(currentInventory.id).state.canSteal) then
+							client.closeInventory()
+							lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+						else
+							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
+						end
+
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > maxDistance or canSteal) then
+						client.closeInventory()
+						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+					end
+				end
+			end
+		end
+
+		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
+			Utils.DeleteEntity(client.parachute[1])
+			client.parachute = false
+		end
+
+		if EnableWeaponWheel then return end
+
+		local weaponHash = GetSelectedPedWeapon(playerPed)
+
+		if currentWeapon then
+			if weaponHash ~= currentWeapon.hash and currentWeapon.timer then
+				local weaponCount = Items[currentWeapon.name]?.count
+
+				if weaponCount > 0 then
+					SetCurrentPedWeapon(playerPed, currentWeapon.hash, true)
+					SetAmmoInClip(playerPed, currentWeapon.hash, currentWeapon.metadata.ammo)
+					SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+
+					weaponHash = GetSelectedPedWeapon(playerPed)
+				end
+
+				if weaponHash ~= currentWeapon.hash then
+                    lib.print.info(('%s was forcibly unequipped (caused by game behaviour or another resource)'):format(currentWeapon.name))
+					currentWeapon = Weapon.Disarm(currentWeapon, true)
+				end
+			end
+		elseif client.weaponmismatch and not client.ignoreweapons[weaponHash] then
+			local weaponType = GetWeapontypeGroup(weaponHash)
+
+			if weaponType ~= 0 and weaponType ~= `GROUP_UNARMED` then
+				Weapon.Disarm(currentWeapon, true)
+			end
+		end
+	end, 200)
+
+	local playerId = cache.playerId
+	local EnableKeys = client.enablekeys
+	local DisablePlayerVehicleRewards = DisablePlayerVehicleRewards
+	local DisableAllControlActions = DisableAllControlActions
+	local HideHudAndRadarThisFrame = HideHudAndRadarThisFrame
+	local EnableControlAction = EnableControlAction
+	local DisablePlayerFiring = DisablePlayerFiring
+	local HudWeaponWheelIgnoreSelection = HudWeaponWheelIgnoreSelection
+	local DisableControlAction = DisableControlAction
+	local IsPedShooting = IsPedShooting
+	local IsControlJustReleased = IsControlJustReleased
+
+	client.tick = SetInterval(function()
+		DisablePlayerVehicleRewards(playerId)
+
+		if invOpen then
+			DisableAllControlActions(0)
+			HideHudAndRadarThisFrame()
+
+			for i = 1, #EnableKeys do
+				EnableControlAction(0, EnableKeys[i], true)
+			end
+
+			if currentInventory.type == 'drop' or currentInventory.type == 'newdrop' then
+				EnableControlAction(0, 30, true)
+				EnableControlAction(0, 31, true)
+			end
+		else
+			if invBusy then
+				DisableControlAction(0, 23, true)
+				DisableControlAction(0, 36, true)
+			end
+
+			if usingItem or invOpen or IsPedCuffed(playerPed) then
+				DisablePlayerFiring(playerId, true)
+			end
+
+			if not EnableWeaponWheel then
+				HudWeaponWheelIgnoreSelection()
+				DisableControlAction(0, 37, true)
+			end
+
+			if currentWeapon and currentWeapon.timer then
+				DisableControlAction(0, 80, true)
+				DisableControlAction(0, 140, true)
+
+				if currentWeapon.metadata.durability <= 0 or not currentWeapon.timer then
+					DisablePlayerFiring(playerId, true)
+				elseif client.aimedfiring and not currentWeapon.melee and currentWeapon.group ~= `GROUP_PETROLCAN` and not IsPlayerFreeAiming(playerId) then
+					DisablePlayerFiring(playerId, true)
+				end
+
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if not invBusy and currentWeapon.timer ~= 0 and currentWeapon.timer < GetGameTimer() then
+					currentWeapon.timer = 0
+
+					if weaponAmmo then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo)
+
+						if client.autoreload and currentWeapon.ammo and GetAmmoInPedWeapon(playerPed, currentWeapon.hash) == 0 then
+							local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+							if slotId then
+								CreateThread(function() useSlot(slotId) end)
+							end
+						end
+
+					elseif currentWeapon.metadata.durability then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'melee', currentWeapon.melee)
+						currentWeapon.melee = 0
+					end
+				elseif weaponAmmo then
+					if IsPedShooting(playerPed) then
+						local currentAmmo
+						local durabilityDrain = Items[currentWeapon.name].durability
+
+						if currentWeapon.group == `GROUP_PETROLCAN` or currentWeapon.group == `GROUP_FIREEXTINGUISHER` then
+							currentAmmo = weaponAmmo - durabilityDrain < 0 and 0 or weaponAmmo - durabilityDrain
+							currentWeapon.metadata.durability = currentAmmo
+							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+
+							if currentAmmo <= 0 then
+								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+							end
+						else
+							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+
+							if currentAmmo < weaponAmmo then
+								currentAmmo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+								currentWeapon.metadata.ammo = currentAmmo
+								currentWeapon.metadata.durability = currentWeapon.metadata.durability - (durabilityDrain * math.abs((weaponAmmo or 0.1) - currentAmmo))
+							end
+						end
+
+						if currentAmmo <= 0 then
+							if cache.vehicle then
+								TaskSwapWeapon(playerPed, true)
+							end
+
+							currentWeapon.timer = GetGameTimer() + 200
+						else currentWeapon.timer = GetGameTimer() + (GetWeaponTimeBetweenShots(currentWeapon.hash) * 1000) + 100 end
+					end
+				elseif currentWeapon.throwable then
+					if not invBusy and IsControlPressed(0, 24) then
+						invBusy = 1
+
+						CreateThread(function()
+							local weapon = currentWeapon
+
+							while currentWeapon and (not IsPedWeaponReadyToShoot(cache.ped) or IsDisabledControlPressed(0, 24)) and GetSelectedPedWeapon(playerPed) == weapon.hash do
+								Wait(0)
+							end
+
+							if GetSelectedPedWeapon(playerPed) == weapon.hash then Wait(700) end
+
+							while IsPedPlantingBomb(playerPed) do Wait(0) end
+
+							TriggerServerEvent('ox_inventory:updateWeapon', 'throw', nil, weapon.slot)
+							plyState:set('invBusy', false, true)
+
+							currentWeapon = nil
+
+							RemoveWeaponFromPed(playerPed, weapon.hash)
+							TriggerEvent('ox_inventory:currentWeapon')
+						end)
+					end
+				elseif currentWeapon.melee and IsControlJustReleased(0, 24) and IsPedPerformingMeleeAction(playerPed) then
+					currentWeapon.melee += 1
+					currentWeapon.timer = GetGameTimer() + 200
+				end
+			end
+		end
+	end)
+
+	plyState:set('invBusy', false, true)
+	plyState:set('invOpen', false, false)
+	plyState:set('invHotkeys', true, false)
+	plyState:set('canUseWeapons', true, false)
+	collectgarbage('collect')
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if shared.resource == resourceName then
+		client.onLogout()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+    currentInventory.type = 'inspect'
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+RegisterNUICallback('uiLoaded', function(_, cb)
+	client.uiLoaded = true
+	cb(1)
+end)
+
+RegisterNUICallback('getItemData', function(itemName, cb)
+	cb(Items[itemName])
+end)
+
+RegisterNUICallback('removeComponent', function(data, cb)
+	cb(1)
+
+	if not currentWeapon then
+		return TriggerServerEvent('ox_inventory:updateWeapon', 'component', data)
+	end
+
+	if data.slot ~= currentWeapon.slot then
+		return lib.notify({ id = 'weapon_hand_wrong', type = 'error', description = locale('weapon_hand_wrong') })
+	end
+
+	local itemSlot = PlayerData.inventory[currentWeapon.slot]
+
+    if not itemSlot then return end
+
+	for _, component in pairs(Items[data.component].client.component) do
+		if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+			for k, v in pairs(itemSlot.metadata.components) do
+				if v == data.component then
+					local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', k)
+
+					if success then
+						RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, component)
+						TriggerEvent('ox_inventory:updateWeaponComponent', 'removed', component, data.component)
+					end
+
+					break
+				end
+			end
+		end
+	end
+end)
+
+RegisterNUICallback('removeAmmo', function(slot, cb)
+	cb(1)
+	local slotData = PlayerData.inventory[slot]
+
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo == 0 then return end
+
+	local success = lib.callback.await('ox_inventory:removeAmmoFromWeapon', false, slot)
+
+	if success and slot == currentWeapon?.slot then
+		SetPedAmmo(playerPed, currentWeapon.hash, 0)
+	end
+end)
+
+RegisterNUICallback('useItem', function(slot, cb)
+	useSlot(slot --[[@as number]])
+	cb(1)
+end)
+
+local function giveItemToTarget(serverId, slotId, count)
+    if type(slotId) ~= 'number' then return TypeError('slotId', 'number', type(slotId)) end
+    if count and type(count) ~= 'number' then return TypeError('count', 'number', type(count)) end
+
+    if slotId == currentWeapon?.slot then
+        currentWeapon = Weapon.Disarm(currentWeapon)
+    end
+
+    Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 1.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+
+    local notification = lib.callback.await('ox_inventory:giveItem', false, slotId, serverId, count or 0)
+
+    if notification then
+        lib.notify({ type = 'error', description = locale(table.unpack(notification)) })
+    end
+end
+
+exports('giveItemToTarget', giveItemToTarget)
+
+local function isGiveTargetValid(ped, coords)
+    if cache.vehicle and GetVehiclePedIsIn(ped, false) == cache.vehicle then
+        return true
+    end
+
+    local entity = Utils.Raycast(1|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
+
+    return entity == ped and IsEntityVisible(ped)
+end
+
+RegisterNUICallback('giveItem', function(data, cb)
+	cb(1)
+
+    if usingItem then return end
+
+	if client.giveplayerlist then
+		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
+
+		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
+        local nearbyCount = #nearbyPlayers
+
+		if nearbyCount == 0 then return end
+
+        if nearbyCount == 1 then
+			local option = nearbyPlayers[1]
+
+            if not isGiveTargetValid(option.ped, option.coords) then return end
+
+            return giveItemToTarget(GetPlayerServerId(option.id), data.slot, data.count)
+        end
+
+        local giveList, n = {}, 0
+
+		for i = 1, #nearbyPlayers do
+			local option = nearbyPlayers[i]
+
+            if isGiveTargetValid(option.ped, option.coords) then
+				local playerName = Utils.getPlayerName(option.id)
+				option.id = GetPlayerServerId(option.id)
+                ---@diagnostic disable-next-line: inject-field
+				option.label = playerName
+				n += 1
+				giveList[n] = option
+			end
+		end
+
+        if n == 0 then return end
+
+		lib.registerMenu({
+			id = 'ox_inventory:givePlayerList',
+			title = 'Give item',
+			options = giveList,
+		}, function(selected)
+            giveItemToTarget(giveList[selected].id, data.slot, data.count)
+        end)
+
+		return lib.showMenu('ox_inventory:givePlayerList')
+	end
+
+    if cache.vehicle then
+		local seats = GetVehicleMaxNumberOfPassengers(cache.vehicle) - 1
+
+		if seats >= 0 then
+			local passenger = GetPedInVehicleSeat(cache.vehicle, cache.seat - 2 * (cache.seat % 2) + 1)
+
+			if passenger ~= 0 and IsEntityVisible(passenger) then
+                return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(passenger)), data.slot, data.count)
+			end
+		end
+
+        return
+	end
+
+    local entity = Utils.Raycast(1|2|4|8|16, GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 3.0, 0.5), 0.2)
+
+    if entity and IsPedAPlayer(entity) and IsEntityVisible(entity) and #(GetEntityCoords(playerPed, true) - GetEntityCoords(entity, true)) < 3.0 then
+        return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(entity)), data.slot, data.count)
+    end
+end)
+
+RegisterNUICallback('useButton', function(data, cb)
+	useButton(data.id, data.slot)
+	cb(1)
+end)
+
+RegisterNUICallback('exit', function(_, cb)
+	client.closeInventory()
+	cb(1)
+end)
+
+lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
+	recipe = CraftingBenches[id].items[recipe]
+
+	return lib.progressCircle({
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
+		duration = recipe.duration or 3000,
+		canCancel = true,
+		disable = {
+			move = true,
+			combat = true,
+		},
+		anim = {
+			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+			clip = 'machinic_loop_mechandplayer',
+		}
+	})
+end)
+
+local swapActive = false
+
+---Synchronise and validate all item movement between the NUI and server.
+RegisterNUICallback('swapItems', function(data, cb)
+    if swapActive or not invOpen or invBusy or usingItem then return cb(false) end
+
+    swapActive = true
+
+	if data.toType == 'newdrop' then
+		if cache.vehicle or IsPedFalling(playerPed) then
+			swapActive = false
+			return cb(false)
+		end
+
+		local coords = GetEntityCoords(playerPed)
+
+		if IsEntityInWater(playerPed) then
+			local destination = vec3(coords.x, coords.y, -200)
+			local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z, 511, cache.ped, 4)
+
+			while true do
+				Wait(0)
+				local retval, hit, endCoords = GetShapeTestResult(handle)
+
+				if retval ~= 1 then
+					if not hit then return end
+
+					data.coords = vec3(endCoords.x, endCoords.y, endCoords.z + 1.0)
+
+					break
+				end
+			end
+		else
+			data.coords = coords
+		end
+    end
+
+	if currentInstance then
+		data.instance = currentInstance
+	end
+
+	if currentWeapon and data.fromType ~= data.toType then
+		if (data.fromType == 'player' and data.fromSlot == currentWeapon.slot) or (data.toType == 'player' and data.toSlot == currentWeapon.slot) then
+			currentWeapon = Weapon.Disarm(currentWeapon, true)
+		end
+	end
+
+	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
+    swapActive = false
+
+	cb(success or false)
+
+	if success then
+        if weaponSlot and currentWeapon then
+            currentWeapon.slot = weaponSlot
+        end
+
+		if response then
+			updateInventory(response.items, response.weight)
+		end
+	elseif response then
+		if type(response) == 'table' then
+			SendNUIMessage({ action = 'refreshSlots', data = { items = response } })
+		else
+			lib.notify({ type = 'error', description = locale(response) })
+		end
+	end
+end)
+
+RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
+	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
+
+	if data then
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
+	end
+
+	if message then
+		lib.notify(message)
+	end
+
+	cb(response)
+end)
+
+RegisterNUICallback('craftItem', function(data, cb)
+	cb(true)
+
+	local id, index = currentInventory.id, currentInventory.index
+
+	for i = 1, data.count do
+		local success, response = lib.callback.await('ox_inventory:craftItem', 200, id, index, data.fromSlot, data.toSlot)
+
+		if not success then
+			if response then lib.notify({ type = 'error', description = locale(response or 'cannot_perform') }) end
+			break
+		end
+	end
+
+	if currentInventory.type ~= 'crafting' then
+		client.openInventory('crafting', { id = id, index = index })
+	end
+end)
+
+lib.callback.register('ox_inventory:getVehicleData', function(netid)
+	local entity = NetworkGetEntityFromNetworkId(netid)
+
+	if entity then
+		return GetEntityModel(entity), GetVehicleClass(entity)
+	end
+end)

--- a/2.47.0/modules/utils/client.lua
+++ b/2.47.0/modules/utils/client.lua
@@ -1,0 +1,312 @@
+if not lib then return end
+
+local Utils = {}
+
+--Holgers Anpassungen
+Utils.Waffensyncaus = false
+--Holgers Anpassungen bis hier
+
+function Utils.PlayAnim(wait, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(cache.ped, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+                                time)
+    lib.requestAnimDict(dict)
+    TaskPlayAnimAdvanced(cache.ped, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+        time, 0, 0)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+---@param flag number
+---@param destination? vector3
+---@param size? number
+---@return number | false
+---@return number?
+function Utils.Raycast(flag, destination, size)
+    local playerCoords = GetEntityCoords(cache.ped)
+    destination = destination or GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)
+    local rayHandle = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x,
+        destination.y, destination.z, size or 2.2, flag or 30, cache.ped, 4)
+    while true do
+        Wait(0)
+        local result, _, coords, _, entityHit = GetShapeTestResult(rayHandle)
+        if result ~= 1 then
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x, destination.y, destination.z, 0, 0, 255, 255)
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, coords.x, coords.y, coords.z, 255, 0, 0, 255)
+            local entityType
+            if entityHit then entityType = GetEntityType(entityHit) end
+            if entityHit and entityType ~= 0 then
+                return entityHit, entityType
+            end
+            return false
+        end
+    end
+end
+
+function Utils.GetClosestPlayer()
+    local players = GetActivePlayers()
+    local playerCoords = GetEntityCoords(cache.ped)
+    local targetDistance, targetId, targetPed
+
+    for i = 1, #players do
+        local player = players[i]
+
+        if player ~= cache.playerId then
+            local ped = GetPlayerPed(player)
+            local distance = #(playerCoords - GetEntityCoords(ped))
+
+            if distance < (targetDistance or 2) then
+                targetDistance = distance
+                targetId = player
+                targetPed = ped
+            end
+        end
+    end
+
+    return targetId, targetPed
+end
+
+-- Replace ox_inventory notify with ox_lib (backwards compatibility)
+function Utils.Notify(data)
+    data.description = data.text
+    data.text = nil
+    lib.notify(data)
+end
+
+RegisterNetEvent('ox_inventory:notify', Utils.Notify)
+exports('notify', Utils.Notify)
+
+local notifySuppressed = false
+
+---@param value boolean
+local function setNotifySuppressed(value)
+    notifySuppressed = value
+end
+
+RegisterNetEvent('ox_inventory:suppressItemNotifications', setNotifySuppressed)
+exports('suppressItemNotifications', setNotifySuppressed)
+
+function Utils.ItemNotify(data)
+    if notifySuppressed or not client.itemnotify then
+        return
+    end
+
+    SendNUIMessage({ action = 'itemNotify', data = data })
+end
+
+RegisterNetEvent('ox_inventory:itemNotify', Utils.ItemNotify)
+
+---@deprecated
+function Utils.DeleteObject(obj)
+    SetEntityAsMissionEntity(obj, false, true)
+    DeleteObject(obj)
+end
+
+function Utils.DeleteEntity(entity)
+    if DoesEntityExist(entity) then
+        SetEntityAsMissionEntity(entity, false, true)
+        DeleteEntity(entity)
+    end
+end
+
+local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
+
+local weaponWheelOverride = false
+
+---Enables the weapon wheel, but disables the use of inventory weapons.
+---Mostly used for weaponised vehicles, though could be called for "minigames"
+---@param state? boolean
+---@param override? boolean
+function Utils.WeaponWheel(state, override)
+    if not override and weaponWheelOverride and state == false then
+        return
+    end
+    if client.disableweapons then state = true end
+    if state == nil then state = EnableWeaponWheel end
+
+    if override then
+        weaponWheelOverride = state or false
+    end
+
+    EnableWeaponWheel = state
+    SetWeaponsNoAutoswap(not state)
+    SetWeaponsNoAutoreload(not state)
+
+    if client.suppresspickups then
+        -- CLEAR_PICKUP_REWARD_TYPE_SUPPRESSION | SUPPRESS_PICKUP_REWARD_TYPE
+        return state and N_0x762db2d380b48d04(rewardTypes) or N_0xf92099527db8e2a7(rewardTypes, true)
+    end
+end
+
+exports('weaponWheel', function (state)
+    Utils.WeaponWheel(state, true)
+end)
+
+--Holgers part starts
+
+function Utils.Waffensyncdisable(state)
+	if state == nil then state = Utils.Waffensyncaus end
+	Utils.Waffensyncaus = state
+	Utils.WeaponWheelsyncen()
+end
+
+Utils.WeaponWheelundHotbar = function(state)
+	if state == nil then state = HotbarundWeaponWheel end
+	HotbarundWeaponWheel = state
+	Utils.WeaponWheel(state)
+end
+
+Utils.WeaponWheelsyncen = function ()
+	Utils.ClearWeapons()
+	if not Utils.Waffensyncaus then		
+		Wait(500)
+		local items = exports.ox_inventory:GetPlayerItems()
+		if items ~=nil  then
+			Waffencache = nil
+			Waffencache = {}
+			for k,v in pairs(items) do
+				if string.sub(v.name,1,7) =="WEAPON_"  and v.name ~= "WEAPON_PETROLCAN" then
+					if HasPedGotWeapon(cache.ped,v.name,false) then
+						RemoveWeaponFromPed(cache.ped,v.name)
+					end
+					local hash = GetHashKey(v.name)
+					Waffencache[hash] = {}
+					Waffencache[hash].name = v.name
+					Waffencache[hash].slot = v.slot
+					Waffencache[hash].hash = hash
+
+					GiveWeaponToPed(cache.ped,v.name,1,false,false)
+				end
+			end
+		end
+	end
+end
+
+exports('Weaponsyncdisable', Utils.Waffensyncdisable)
+exports('WeaponWheelandHotbar', Utils.WeaponWheelundHotbar)
+
+--Holgers part ends
+
+function Utils.CreateBlip(settings, coords)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, settings.id)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, settings.scale)
+    SetBlipColour(blip, settings.colour)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName(settings.name)
+    EndTextCommandSetBlipName(blip)
+
+    return blip
+end
+
+---Takes OxTargetBoxZone or legacy zone data (PolyZone) and creates a zone.
+---@param data OxTargetBoxZone | { length: number, minZ: number, maxZ: number, loc: vector3, heading: number, width: number, distance: number }
+---@param options? OxTargetOption[]
+---@return number
+function Utils.CreateBoxZone(data, options)
+    if data.length then
+        local height = math.abs(data.maxZ - data.minZ)
+        local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2
+        data.coords = vec3(data.loc.x, data.loc.y, z)
+        data.size = vec3(data.width, data.length, height)
+        data.rotation = data.heading
+        data.loc = nil
+        data.heading = nil
+        data.length = nil
+        data.width = nil
+        data.maxZ = nil
+        data.minZ = nil
+    end
+
+    if not data.options and options then
+        local distance = data.distance or 2.0
+
+        for k, v in pairs(options) do
+            if not v.distance then
+                v.distance = distance
+            end
+        end
+
+        data.options = options
+    end
+
+    return exports.ox_target:addBoxZone(data)
+end
+
+local hasTextUi
+
+---@param point CPoint
+function Utils.nearbyMarker(point)
+    DrawMarker(point.marker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, point.marker.scale[1], point.marker.scale[2], point.marker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        point.marker.colour[1], point.marker.colour[2], point.marker.colour[3], 222, false, false, 0, true, false, false, false)
+
+    if point.isClosest and point.currentDistance < 1.2 then
+        if not hasTextUi then
+            hasTextUi = point
+            lib.showTextUI(point.prompt.message, point.prompt.options)
+        end
+
+        if IsControlJustReleased(0, 38) then
+            CreateThread(function()
+                if point.inv == 'policeevidence' then
+                    client.openInventory('policeevidence')
+                elseif point.inv == 'crafting' then
+                    client.openInventory('crafting', { id = point.benchid, index = point.index })
+                else
+                    client.openInventory(point.inv or 'drop', { id = point.invId, type = point.type })
+                end
+            end)
+        end
+    elseif hasTextUi == point then
+        hasTextUi = nil
+        lib.hideTextUI()
+    end
+end
+
+function Utils.blurIn()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeIn(100)
+end
+
+function Utils.blurOut()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeOut(250)
+end
+
+---@param serverID number
+---@return string
+local function defaultGetPlayerName(serverID)
+    local playerName = GetPlayerName(serverID)
+    return ('[%d] %s'):format(serverID, playerName)
+end
+
+local getPlayerName = defaultGetPlayerName
+
+exports('setGetPlayerNameMethod', function (fn)
+    if type(fn) == "function" then
+        getPlayerName = fn
+    else
+        getPlayerName = defaultGetPlayerName
+    end
+end)
+
+function Utils.getPlayerName(serverId)
+    return getPlayerName(serverId)
+end
+
+return Utils

--- a/2.47.0/modules/weapon/client.lua
+++ b/2.47.0/modules/weapon/client.lua
@@ -1,0 +1,666 @@
+if not lib then return end
+
+local Weapon = {}
+local Items = require 'modules.items.client'
+local Utils = require 'modules.utils.client'
+
+-- generic group animation data
+local anims = {}
+anims[`GROUP_MELEE`] = { 'melee@holster', 'unholster', 200, 'melee@holster', 'holster', 600 }
+anims[`GROUP_PISTOL`] = { 'reaction@intimidation@cop@unarmed', 'intro', 400, 'reaction@intimidation@cop@unarmed', 'outro', 450 }
+anims[`GROUP_STUNGUN`] = anims[`GROUP_PISTOL`]
+
+local function vehicleIsCycle(vehicle)
+	local class = GetVehicleClass(vehicle)
+	return class == 8 or class == 13
+end
+
+function Weapon.Equip(item, data, noWeaponAnim)
+	local playerPed = cache.ped
+	local coords = GetEntityCoords(playerPed, true)
+    local sleep
+
+	if client.weaponanims then
+		if noWeaponAnim or (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			goto skipAnim
+		end
+
+		local anim = data.anim or anims[GetWeapontypeGroup(data.hash)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+		sleep = anim and anim[3] or 1200
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+	end
+
+	::skipAnim::
+
+	GiveWeaponToPed(playerPed, -1569615261, 0, false, true) --added by Holger
+
+	item.hash = data.hash
+	item.ammo = data.ammoname
+	item.melee = GetWeaponDamageType(data.hash) == 2 and 0
+	item.timer = 0
+	item.throwable = data.throwable
+	item.group = GetWeapontypeGroup(item.hash)
+
+	GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+
+	if item.metadata.tint then SetPedWeaponTintIndex(playerPed, data.hash, item.metadata.tint) end
+
+	if item.metadata.components then
+		for i = 1, #item.metadata.components do
+			local components = Items[item.metadata.components[i]].client.component
+			for v=1, #components do
+				local component = components[v]
+				if DoesWeaponTakeWeaponComponent(data.hash, component) then
+					if not HasPedGotWeaponComponent(playerPed, data.hash, component) then
+						GiveWeaponComponentToPed(playerPed, data.hash, component)
+					end
+				end
+			end
+		end
+	end
+
+	if item.metadata.specialAmmo then
+		local clipComponentKey = ('%s_CLIP'):format(data.model:gsub('WEAPON_', 'COMPONENT_'))
+		local specialClip = ('%s_%s'):format(clipComponentKey, item.metadata.specialAmmo:upper())
+
+		if DoesWeaponTakeWeaponComponent(data.hash, specialClip) then
+			GiveWeaponComponentToPed(playerPed, data.hash, specialClip)
+		end
+	end
+
+	local ammo = item.metadata.ammo or item.throwable and 1 or 0
+
+	SetCurrentPedWeapon(playerPed, data.hash, true)
+	SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+	SetWeaponsNoAutoswap(true)
+	SetPedAmmo(playerPed, data.hash, ammo)
+	SetTimeout(0, function() RefillAmmoInstantly(playerPed) end)
+
+	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
+		item.metadata.ammo = item.metadata.durability
+		SetPedInfiniteAmmo(playerPed, true, data.hash)
+	end
+
+	TriggerEvent('ox_inventory:currentWeapon', item)
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
+
+	return item, sleep
+end
+
+function Weapon.Disarm(currentWeapon, noAnim, waffenlos) --waffenlos added by Holger
+	if currentWeapon?.timer then
+		currentWeapon.timer = nil
+
+        TriggerServerEvent('ox_inventory:updateWeapon')
+		--SetPedAmmo(cache.ped, currentWeapon.hash, 0)	--disabled by Holger
+
+		if client.weaponanims and not noAnim then
+			if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+				goto skipAnim
+			end
+
+			ClearPedSecondaryTask(cache.ped)
+
+			local item = Items[currentWeapon.name]
+			local coords = GetEntityCoords(cache.ped, true)
+			local anim = item.anim or anims[GetWeapontypeGroup(currentWeapon.hash)]
+
+			if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+				anim = nil
+			end
+
+			local sleep = anim and anim[6] or 1400
+
+			Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+		end
+
+		::skipAnim::
+
+		if waffenlos then	--if added by Holger
+			GiveWeaponToPed(cache.ped, currentWeapon.hash, 0, false, true)
+		end
+
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
+		TriggerEvent('ox_inventory:currentWeapon')
+	end
+
+end --closing end for Weapon.Disarm
+
+--[[ 	Utils.WeaponWheel() --disabled by Holger
+	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
+	end
+end ]]
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+
+--Holgers part starts
+
+
+Weapon.triggerAnimation = function(waffenhashalt,waffenhashneu,wert)
+	if wert then
+		local playerPed = cache.ped
+		local coords = GetEntityCoords(playerPed, true)
+		local sleep
+
+		if  (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			return
+		end
+
+		local anim = anims[GetWeapontypeGroup(waffenhashneu)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+
+		sleep = anim and anim[3] or 1100
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+
+		GiveWeaponToPed(playerPed, waffenhashneu, 250, false, true)
+		sleep = 0
+
+	else
+		if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+			return
+		end
+		local sleep
+
+
+		ClearPedSecondaryTask(cache.ped)
+
+		local coords = GetEntityCoords(cache.ped, true)
+		local anim = anims[GetWeapontypeGroup(waffenhashalt)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		local sleep = anim and anim[6] or 1000
+
+		GiveWeaponToPed(cache.ped, waffenhashalt, 0, false, true)
+		
+		Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+	end
+
+end
+
+--Holgers part ends
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+--added by Holger thanks to 5Labs for providing the list
+
+Weapon.WeaponByHash = {
+	[-1768145561] = {
+	["name"] = 'WEAPON_SPECIALCARBINE_MK2',
+	["label"] = 'Special Carbine MK2',
+	},
+	[487013001] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN',
+	["label"] = 'Pump Shotgun',
+	},
+	[-1075685676] = {
+	["name"] = 'WEAPON_PISTOL_MK2',
+	["label"] = 'Pistol MK2',
+	},
+	[-1238556825] = {
+	["name"] = 'WEAPON_RAYMINIGUN',
+	["label"] = 'Widowmaker',
+	},
+	[-1834847097] = {
+	["name"] = 'WEAPON_DAGGER',
+	["label"] = 'Dagger',
+	},
+	[-2067956739] = {
+	["name"] = 'WEAPON_CROWBAR',
+	["label"] = 'Crowbar',
+	},
+	[650961374] = {
+	["name"] = 'WEAPON_TEARGAS',
+	["label"] = 'Tear Gas',
+	},
+	[-618237638] = {
+	["name"] = 'WEAPON_EMPLAUNCHER',
+	["label"] = 'Compact EMP Launcher',
+	},
+	[-2084633992] = {
+	["name"] = 'WEAPON_CARBINERIFLE',
+	["label"] = 'Carbine Rifle',
+	},
+	[940833800] = {
+	["name"] = 'WEAPON_STONE_HATCHET',
+	["label"] = 'Stone Hatchet',
+	},
+	[-1716589765] = {
+	["name"] = 'WEAPON_PISTOL50',
+	["label"] = 'Pistol .50',
+	},
+	[-1716189206] = {
+	["name"] = 'WEAPON_KNIFE',
+	["label"] = 'Knife',
+	},
+	[1853742572] = {
+	["name"] = 'WEAPON_PRECISIONRIFLE',
+	["label"] = 'Precision Rifle',
+	},
+	[-1076751822] = {
+	["name"] = 'WEAPON_SNSPISTOL',
+	["label"] = 'SNS Pistol',
+	},
+	[1198879012] = {
+	["name"] = 'WEAPON_FLAREGUN',
+	["label"] = 'Flare Gun',
+	},
+	[-1355376991] = {
+	["name"] = 'WEAPON_RAYPISTOL',
+	["label"] = 'Up-n-Atomizer',
+	},
+	[-1813897027] = {
+	["name"] = 'WEAPON_GRENADE',
+	["label"] = 'Grenade',
+	},
+	[1737195953] = {
+	["name"] = 'WEAPON_NIGHTSTICK',
+	["label"] = 'Nightstick',
+	},
+	[1198256469] = {
+	["name"] = 'WEAPON_RAYCARBINE',
+	["label"] = 'Unholy Hellbringer',
+	},
+	[465894841] = {
+	["name"] = 'WEAPON_PISTOLXM3',
+	["label"] = 'WM 29 Pistol',
+	},
+	[1432025498] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN_MK2',
+	["label"] = 'Pump Shotgun MK2',
+	},
+	[100416529] = {
+	["name"] = 'WEAPON_SNIPERRIFLE',
+	["label"] = 'Sniper Rifle',
+	},
+	[1593441988] = {
+	["name"] = 'WEAPON_COMBATPISTOL',
+	["label"] = 'Glock',
+	},
+	[-581044007] = {
+	["name"] = 'WEAPON_MACHETE',
+	["label"] = 'Machete',
+	},
+	[-275439685] = {
+	["name"] = 'WEAPON_DBSHOTGUN',
+	["label"] = 'Double Barrel Shotgun',
+	},
+	[-1063057011] = {
+	["name"] = 'WEAPON_SPECIALCARBINE',
+	["label"] = 'Special Carbine',
+	},
+	[-1951375401] = {
+	["name"] = 'WEAPON_FLASHLIGHT',
+	["label"] = 'Flashlight',
+	},
+	[727643628] = {
+	["name"] = 'WEAPON_CERAMICPISTOL',
+	["label"] = 'Ceramic Pistol',
+	},
+	[584646201] = {
+	["name"] = 'WEAPON_APPISTOL',
+	["label"] = 'AP Pistol',
+	},
+	[-1045183535] = {
+	["name"] = 'WEAPON_REVOLVER',
+	["label"] = 'Revolver',
+	},
+	[-22923932] = {
+	["name"] = 'WEAPON_RAILGUNXM3',
+	["label"] = 'Railgun XM3',
+	},
+	[324215364] = {
+	["name"] = 'WEAPON_MICROSMG',
+	["label"] = 'Micro SMG',
+	},
+	[-1600701090] = {
+	["name"] = 'WEAPON_BZGAS',
+	["label"] = 'BZ Gas',
+	},
+	[-1168940174] = {
+	["name"] = 'WEAPON_HAZARDCAN',
+	["label"] = 'Hazard Can',
+	},
+	[-608341376] = {
+	["name"] = 'WEAPON_COMBATMG_MK2',
+	["label"] = 'Combat MG MK2',
+	},
+	[-538741184] = {
+	["name"] = 'WEAPON_SWITCHBLADE',
+	["label"] = 'Switchblade',
+	},
+	[984333226] = {
+	["name"] = 'WEAPON_HEAVYSHOTGUN',
+	["label"] = 'Heavy Shotgun',
+	},
+	[1785463520] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE_MK2',
+	["label"] = 'Marksman Rifle MK2',
+	},
+	[2024373456] = {
+	["name"] = 'WEAPON_SMG_MK2',
+	["label"] = 'SMG Mk2',
+	},
+	[1649403952] = {
+	["name"] = 'WEAPON_COMPACTRIFLE',
+	["label"] = 'Compact Rifle',
+	},
+	[615608432] = {
+	["name"] = 'WEAPON_MOLOTOV',
+	["label"] = 'Molotov',
+	},
+	[600439132] = {
+	["name"] = 'WEAPON_BALL',
+	["label"] = 'Ball',
+	},
+	[-952879014] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE',
+	["label"] = 'Marksman Rifle',
+	},
+	[-610080759] = {
+	["name"] = 'WEAPON_METALDETECTOR',
+	["label"] = 'Metal Detector',
+	},
+	[2017895192] = {
+	["name"] = 'WEAPON_SAWNOFFSHOTGUN',
+	["label"] = 'Sawn Off Shotgun',
+	},
+	[-1568386805] = {
+	["name"] = 'WEAPON_GRENADELAUNCHER',
+	["label"] = 'Grenade Launcher',
+	},
+	[-270015777] = {
+	["name"] = 'WEAPON_ASSAULTSMG',
+	["label"] = 'Assault SMG',
+	},
+	[-1466123874] = {
+	["name"] = 'WEAPON_MUSKET',
+	["label"] = 'Musket',
+	},
+	[-37975472] = {
+	["name"] = 'WEAPON_SMOKEGRENADE',
+	["label"] = 'Smoke Grenade',
+	},
+	[-1654528753] = {
+	["name"] = 'WEAPON_BULLPUPSHOTGUN',
+	["label"] = 'Bullpup Shotgun',
+	},
+	[1317494643] = {
+	["name"] = 'WEAPON_HAMMER',
+	["label"] = 'Hammer',
+	},
+	[137902532] = {
+	["name"] = 'WEAPON_VINTAGEPISTOL',
+	["label"] = 'Vintage Pistol',
+	},
+	[-853065399] = {
+	["name"] = 'WEAPON_BATTLEAXE',
+	["label"] = 'Battle Axe',
+	},
+	[-1660422300] = {
+	["name"] = 'WEAPON_MG',
+	["label"] = 'Machine Gun',
+	},
+	[1470379660] = {
+	["name"] = 'WEAPON_GADGETPISTOL',
+	["label"] = 'Perico Pistol',
+	},
+	[-1853920116] = {
+	["name"] = 'WEAPON_NAVYREVOLVER',
+	["label"] = 'Navy Revolver',
+	},
+	[94989220] = {
+	["name"] = 'WEAPON_COMBATSHOTGUN',
+	["label"] = 'Combat Shotgun',
+	},
+	[2144741730] = {
+	["name"] = 'WEAPON_COMBATMG',
+	["label"] = 'Combat MG',
+	},
+	[317205821] = {
+	["name"] = 'WEAPON_AUTOSHOTGUN',
+	["label"] = 'Sweeper Shotgun',
+	},
+	[883325847] = {
+	["name"] = 'WEAPON_PETROLCAN',
+	["label"] = 'Gas Can',
+	},
+	[-1357824103] = {
+	["name"] = 'WEAPON_ADVANCEDRIFLE',
+	["label"] = 'Advanced Rifle',
+	},
+	[736523883] = {
+	["name"] = 'WEAPON_SMG',
+	["label"] = 'SMG',
+	},
+	[205991906] = {
+	["name"] = 'WEAPON_HEAVYSNIPER',
+	["label"] = 'Heavy Sniper',
+	},
+	[-1312131151] = {
+	["name"] = 'WEAPON_RPG',
+	["label"] = 'RPG',
+	},
+	[-771403250] = {
+	["name"] = 'WEAPON_HEAVYPISTOL',
+	["label"] = 'Heavy Pistol',
+	},
+	[-879347409] = {
+	["name"] = 'WEAPON_REVOLVER_MK2',
+	["label"] = 'Revolver MK2',
+	},
+	[-494615257] = {
+	["name"] = 'WEAPON_ASSAULTSHOTGUN',
+	["label"] = 'Assault Shotgun',
+	},
+	[-947031628] = {
+	["name"] = 'WEAPON_HEAVYRIFLE',
+	["label"] = 'Heavy Rifle',
+	},
+	[-1420407917] = {
+	["name"] = 'WEAPON_PROXMINE',
+	["label"] = 'Proximity Mine',
+	},
+	[-619010992] = {
+	["name"] = 'WEAPON_MACHINEPISTOL',
+	["label"] = 'Machine Pistol',
+	},
+	[-1746263880] = {
+	["name"] = 'WEAPON_DOUBLEACTION',
+	["label"] = 'Double Action Revolver',
+	},
+	[125959754] = {
+	["name"] = 'WEAPON_COMPACTLAUNCHER',
+	["label"] = 'Compact Grenade Launcher',
+	},
+	[2132975508] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE',
+	["label"] = 'Bullpup Rifle',
+	},
+	[-86904375] = {
+	["name"] = 'WEAPON_CARBINERIFLE_MK2',
+	["label"] = 'Carbine Rifle MK2',
+	},
+	[453432689] = {
+	["name"] = 'WEAPON_PISTOL',
+	["label"] = 'Pistol',
+	},
+	[-1074790547] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE',
+	["label"] = 'Assault Rifle',
+	},
+	[1627465347] = {
+	["name"] = 'WEAPON_GUSENBERG',
+	["label"] = 'Gusenberg',
+	},
+	[911657153] = {
+	["name"] = 'WEAPON_STUNGUN',
+	["label"] = 'Tazer',
+	},
+	[-1121678507] = {
+	["name"] = 'WEAPON_MINISMG',
+	["label"] = 'Mini SMG',
+	},
+	[171789620] = {
+	["name"] = 'WEAPON_COMBATPDW',
+	["label"] = 'Combat PDW',
+	},
+	[1141786504] = {
+	["name"] = 'WEAPON_GOLFCLUB',
+	["label"] = 'Golf Club',
+	},
+	[1834241177] = {
+	["name"] = 'WEAPON_RAILGUN',
+	["label"] = 'Railgun',
+	},
+	[1119849093] = {
+	["name"] = 'WEAPON_MINIGUN',
+	["label"] = 'Minigun',
+	},
+	[961495388] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE_MK2',
+	["label"] = 'Assault Rifle MK2',
+	},
+	[406929569] = {
+	["name"] = 'WEAPON_FERTILIZERCAN',
+	["label"] = 'Fertilizer Can',
+	},
+	[1233104067] = {
+	["name"] = 'WEAPON_FLARE',
+	["label"] = 'Flare',
+	},
+	[419712736] = {
+	["name"] = 'WEAPON_WRENCH',
+	["label"] = 'Wrench',
+	},
+	[-2009644972] = {
+	["name"] = 'WEAPON_SNSPISTOL_MK2',
+	["label"] = 'SNS Pistol MK2',
+	},
+	[-102973651] = {
+	["name"] = 'WEAPON_HATCHET',
+	["label"] = 'Hatchet',
+	},
+	[-2066285827] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE_MK2',
+	["label"] = 'Bullpup Rifle MK2',
+	},
+	[-1169823560] = {
+	["name"] = 'WEAPON_PIPEBOMB',
+	["label"] = 'Pipe Bomb',
+	},
+	[1703483498] = {
+	["name"] = 'WEAPON_CANDYCANE',
+	["label"] = 'Candy Cane',
+	},
+	[-598887786] = {
+	["name"] = 'WEAPON_MARKSMANPISTOL',
+	["label"] = 'Marksman Pistol',
+	},
+	[350597077] = {
+	["name"] = 'WEAPON_TECPISTOL',
+	["label"] = 'Tactical SMG',
+	},
+	[-1786099057] = {
+	["name"] = 'WEAPON_BAT',
+	["label"] = 'Bat',
+	},
+	[2138347493] = {
+	["name"] = 'WEAPON_FIREWORK',
+	["label"] = 'Firework Launcher',
+	},
+	[-1658906650] = {
+	["name"] = 'WEAPON_MILITARYRIFLE',
+	["label"] = 'Military Rifle',
+	},
+	[-656458692] = {
+	["name"] = 'WEAPON_KNUCKLE',
+	["label"] = 'Knuckle Dusters',
+	},
+	[126349499] = {
+	["name"] = 'WEAPON_SNOWBALL',
+	["label"] = 'Snow Ball',
+	},
+	[177293209] = {
+	["name"] = 'WEAPON_HEAVYSNIPER_MK2',
+	["label"] = 'Heavy Sniper MK2',
+	},
+	[-774507221] = {
+	["name"] = 'WEAPON_TACTICALRIFLE',
+	["label"] = 'Tactical Rifle',
+	},
+	[101631238] = {
+	["name"] = 'WEAPON_FIREEXTINGUISHER',
+	["label"] = 'Fire Extinguisher',
+	},
+	[-102323637] = {
+	["name"] = 'WEAPON_BOTTLE',
+	["label"] = 'Bottle',
+	},
+	[741814745] = {
+	["name"] = 'WEAPON_STICKYBOMB',
+	["label"] = 'Sticky Bomb',
+	},
+	[1672152130] = {
+	["name"] = 'WEAPON_HOMINGLAUNCHER',
+	["label"] = 'Homing Launcher',
+	},
+	[-1810795771] = {
+	["name"] = 'WEAPON_POOLCUE',
+	["label"] = 'Pool Cue',
+	},
+}
+
+
+return Weapon

--- a/2.47.1/client.lua
+++ b/2.47.1/client.lua
@@ -1,0 +1,2012 @@
+if not lib then return end
+
+require 'modules.bridge.client'
+require 'modules.interface.client'
+
+local Utils = require 'modules.utils.client'
+local Weapon = require 'modules.weapon.client'
+local currentWeapon
+
+--Holgers Anpassungen
+HotbarundWeaponWheel = false
+EnableWeaponWheel = true
+Waffencache = {}
+--Holgers Anpassungen bis hier
+
+exports('getCurrentWeapon', function()
+	return currentWeapon
+end)
+
+RegisterNetEvent('ox_inventory:disarm', function(noAnim)
+	currentWeapon = Weapon.Disarm(currentWeapon, noAnim)
+end)
+
+RegisterNetEvent('ox_inventory:clearWeapons', function()
+	Weapon.ClearAll(currentWeapon)
+end)
+
+local StashTarget
+
+exports('setStashTarget', function(id, owner)
+	StashTarget = id and {id=id, owner=owner}
+end)
+
+---@type boolean | number
+local invBusy = true
+
+---@type boolean?
+local invOpen = false
+local plyState = LocalPlayer.state
+local IsPedCuffed = IsPedCuffed
+local playerPed = cache.ped
+
+lib.onCache('ped', function(ped)
+	playerPed = ped
+	Utils.WeaponWheel()
+end)
+
+plyState:set('invBusy', true, true)
+plyState:set('invHotkeys', false, false)
+plyState:set('canUseWeapons', false, false)
+
+local function canOpenInventory()
+    if not PlayerData.loaded then
+        return shared.info('cannot open inventory', '(player inventory has not loaded)')
+    end
+
+    if IsPauseMenuActive() then return end
+
+    if invBusy or invOpen == nil or (currentWeapon?.timer or 0) > 0 then
+        return shared.info('cannot open inventory', '(is busy)')
+    end
+
+    if PlayerData.dead or IsPedFatallyInjured(playerPed) then
+        return shared.info('cannot open inventory', '(fatal injury)')
+    end
+
+    if PlayerData.cuffed or IsPedCuffed(playerPed) then
+        return shared.info('cannot open inventory', '(cuffed)')
+    end
+
+    return true
+end
+
+---@param ped number
+---@return boolean
+local function canOpenTarget(ped)
+	return IsPedFatallyInjured(ped)
+	or IsEntityPlayingAnim(ped, 'dead', 'dead_a', 3)
+	or IsPedCuffed(ped)
+	or IsEntityPlayingAnim(ped, 'mp_arresting', 'idle', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 3)
+	or IsEntityPlayingAnim(ped, 'missminuteman_1ig_2', 'handsup_enter', 3)
+	or IsEntityPlayingAnim(ped, 'random@mugging3', 'handsup_standing_base', 3)
+end
+
+---@class OpenInventory
+---@field id string | integer
+---@field label string
+---@field type string
+---@field slots integer
+---@field weight integer
+---@field maxWeight integer
+---@field coords? vector3
+---@field distance? integer
+---@field instance? string | number
+---@field [string] unknown
+local defaultInventory = {
+	type = 'newdrop',
+	slots = shared.dropslots,
+	weight = 0,
+	maxWeight = shared.dropweight,
+	items = {}
+}
+
+local currentInventory = defaultInventory
+
+local function closeTrunk()
+	if currentInventory.type == 'trunk' then
+		local coords = GetEntityCoords(playerPed, true)
+		---@todo animation for vans?
+		Utils.PlayAnimAdvanced(0, 'anim@heists@fleeca_bank@scope_out@return_case', 'trevor_action', coords.x, coords.y, coords.z, 0.0, 0.0, GetEntityHeading(playerPed), 2.0, 2.0, 1000, 49, 0.25)
+
+		CreateThread(function()
+			local entity = currentInventory.entity
+			local door = currentInventory.door
+			Wait(900)
+
+			if type(door) == 'table' then
+				for i = 1, #door do
+					SetVehicleDoorShut(entity, door[i], false)
+				end
+			else
+				SetVehicleDoorShut(entity, door, false)
+			end
+		end)
+	end
+end
+
+local CraftingBenches = require 'modules.crafting.client'
+local Vehicles = lib.load('data.vehicles')
+local Inventory = require 'modules.inventory.client'
+
+---@param inv string?
+---@param data any?
+---@return boolean?
+function client.openInventory(inv, data)
+	if invOpen then
+		if not inv and currentInventory.type == 'newdrop' then
+			return client.closeInventory()
+		end
+
+		if IsNuiFocused() then
+			if inv == 'container' and currentInventory.id == PlayerData.inventory[data].metadata.container then
+				return client.closeInventory()
+			end
+
+			if currentInventory.type == 'drop' and (not data or currentInventory.id == (type(data) == 'table' and data.id or data)) then
+				return client.closeInventory()
+			end
+
+			if inv ~= 'drop' and inv ~= 'container' then
+				if (data?.id or data) == currentInventory.id then
+					-- Triggering exports.ox_inventory:openInventory('stash', 'mystash') twice in rapid succession is weird behaviour
+					return warn(("script tried to open inventory, but it is already open\n%s"):format(Citizen.InvokeNative(`FORMAT_STACK_TRACE` & 0xFFFFFFFF, nil, 0, Citizen.ResultAsString())))
+				else
+					return client.closeInventory()
+				end
+			end
+		end
+	elseif IsNuiFocused() then
+		-- If triggering from another nui, may need to wait for focus to end.
+		Wait(100)
+
+        -- People still complain about this being an "error" and ask "how fix" despite being a warning
+        -- for people with above room-temperature iqs to look into resource conflicts on their own.
+		-- if IsNuiFocused() then
+		-- 	warn('other scripts have nui focus and may cause issues (e.g. disable focus, prevent input, overlap inventory window)')
+		-- end
+	end
+
+	if inv == 'dumpster' and cache.vehicle then
+		return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+	end
+
+	if not canOpenInventory() then
+        return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+    end
+
+    local left, right, accessError
+
+    if inv == 'player' and data ~= cache.serverId then
+        local targetId, targetPed, serverId
+
+        if not data then
+            targetId, targetPed = Utils.GetClosestPlayer()
+            serverId = targetId and GetPlayerServerId(targetId)
+            data = serverId
+        else
+            serverId = type(data) == 'table' and data.id or data
+            targetId = serverId and GetPlayerFromServerId(serverId)
+            targetPed = targetId and GetPlayerPed(targetId)
+        end
+
+        if serverId == cache.serverId then return end
+
+        local targetCoords = targetPed and GetEntityCoords(targetPed)
+
+        if not targetCoords or #(targetCoords - GetEntityCoords(playerPed)) > 1.8 or (not client.hasGroup(shared.police) and not Player(serverId).state.canSteal) then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+    end
+
+    if inv == 'shop' and invOpen == false then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openShop', 200, data)
+    elseif inv == 'crafting' then
+        if cache.vehicle then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openCraftingBench', 200, data.id, data.index)
+
+        if left then
+            right = CraftingBenches[data.id]
+
+            if not right?.items then return end
+
+            local coords, distance
+
+            if not right.zones and not right.points then
+                coords = GetEntityCoords(cache.ped)
+                distance = 2
+            else
+                coords = shared.target and right.zones and right.zones[data.index].coords or right.points and right.points[data.index]
+                distance = coords and shared.target and right.zones[data.index].distance or 2
+            end
+
+            right = {
+                type = 'crafting',
+                id = data.id,
+                label = right.label or locale('crafting_bench'),
+                index = data.index,
+                slots = right.slots,
+                items = right.items,
+                coords = coords,
+                distance = distance
+            }
+        end
+    elseif invOpen ~= nil then
+        if inv == 'policeevidence' then
+            if not data then
+                local input = lib.inputDialog(locale('police_evidence'), {
+                    { label = locale('locker_number'), type = 'number', required = true, icon = 'calculator' }
+                }) --[[@as number[]? ]]
+
+                if not input then return end
+
+                data = input[1]
+            end
+        end
+
+        left, right, accessError = lib.callback.await('ox_inventory:openInventory', false, inv, data)
+    end
+
+    if accessError then
+        return lib.notify({ id = accessError, type = 'error', description = locale(accessError) })
+    end
+
+    -- Stash does not exist
+    if not left then
+        if left == false then return false end
+
+        if invOpen == false then
+            return lib.notify({ id = 'inventory_right_access', type = 'error', description = locale('inventory_right_access') })
+        end
+
+        if invOpen then return client.closeInventory() end
+    end
+
+
+    if not cache.vehicle then
+        if inv == 'player' then
+            Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 8.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+        elseif inv ~= 'trunk' then
+            Utils.PlayAnim(0, 'pickup_object', 'putdown_low', 5.0, 1.5, 1000, 48, 0.0, 0, 0, 0)
+        end
+    end
+
+    plyState.invOpen = true
+
+    SetInterval(client.interval, 100)
+    SetNuiFocus(true, true)
+    SetNuiFocusKeepInput(true)
+    closeTrunk()
+
+    if client.screenblur then Utils.blurIn() end
+
+    currentInventory = right or defaultInventory
+    left.items = PlayerData.inventory
+    left.groups = PlayerData.groups
+
+    SendNUIMessage({
+        action = 'setupInventory',
+        data = {
+            leftInventory = left,
+            rightInventory = currentInventory
+        }
+    })
+
+    if inv and not currentInventory.coords and inv ~= 'container' and inv ~= 'glovebox' then
+        currentInventory.coords = GetEntityCoords(playerPed)
+    end
+
+    if inv == 'trunk' then
+        SetTimeout(200, function()
+            ---@todo animation for vans?
+            Utils.PlayAnim(0, 'anim@heists@prison_heiststation@cop_reactions', 'cop_b_idle', 3.0, 3.0, -1, 49, 0.0, 0, 0, 0)
+
+            local entity = data.entity or NetworkGetEntityFromNetworkId(data.netid)
+            currentInventory.entity = entity
+            currentInventory.door = data.door
+
+            if not currentInventory.door then
+                local vehicleHash = GetEntityModel(entity)
+                local vehicleClass = GetVehicleClass(entity)
+                currentInventory.door = vehicleClass == 12 and { 2, 3 } or Vehicles.Storage[vehicleHash] and 4 or 5
+            end
+
+            while currentInventory.entity == entity and invOpen and DoesEntityExist(entity) and Inventory.CanAccessTrunk(entity) do
+                Wait(100)
+            end
+
+            if invOpen then client.closeInventory() end
+        end)
+    end
+
+    return true
+end
+
+RegisterNetEvent('ox_inventory:openInventory', client.openInventory)
+exports('openInventory', client.openInventory)
+
+RegisterNetEvent('ox_inventory:forceOpenInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+local Animations = lib.load('data.animations')
+local Items = require 'modules.items.client'
+local usingItem = false
+
+---@param data { name: string, label: string, count: number, slot: number, metadata: table<string, any>, weight: number }
+lib.callback.register('ox_inventory:usingItem', function(data, noAnim)
+	local item = Items[data.name]
+
+	if item and usingItem then
+		if not item.client then return true end
+		---@cast item +OxClientProps
+		item = item.client
+
+		if type(item.anim) == 'string' then
+			item.anim = Animations.anim[item.anim]
+		end
+
+		if item.prop then
+			if item.prop[1] then
+				for i = 1, #item.prop do
+					if type(item.prop) == 'string' then
+						item.prop = Animations.prop[item.prop[i]]
+					end
+				end
+			elseif type(item.prop) == 'string' then
+				item.prop = Animations.prop[item.prop]
+			end
+		end
+
+		if not item.disable then
+			item.disable = { combat = true }
+		elseif item.disable.combat == nil then
+			-- Backwards compatibility; you probably don't want people shooting while eating and bandaging anyway
+			item.disable.combat = true
+		end
+
+		local success = (not item.usetime or noAnim or lib.progressBar({
+			duration = item.usetime,
+			label = item.label or locale('using', data.metadata.label or data.label),
+			useWhileDead = item.useWhileDead,
+			canCancel = item.cancel,
+			disable = item.disable,
+			anim = item.anim or item.scenario,
+			prop = item.prop --[[@as ProgressProps]]
+		})) and not PlayerData.dead
+
+		if success then
+			if item.notification then
+				lib.notify({ description = item.notification })
+			end
+
+			if item.status then
+				if client.setPlayerStatus then
+					client.setPlayerStatus(item.status)
+				end
+			end
+
+			return true
+		end
+	end
+end)
+
+local function canUseItem(isAmmo)
+	local ped = cache.ped
+
+	return not usingItem
+    and (not isAmmo or currentWeapon)
+	and PlayerData.loaded
+	and not PlayerData.dead
+	and not invBusy
+	and not lib.progressActive()
+	and not IsPedRagdoll(ped)
+	and not IsPedFalling(ped)
+    and not IsPedShooting(playerPed)
+end
+
+---@param data table
+---@param cb fun(response: SlotWithItem | false)?
+---@param noAnim? boolean
+local function useItem(data, cb, noAnim)
+	local slotData, result = PlayerData.inventory[data.slot]
+
+	if not slotData or not canUseItem(data.ammo and true) then
+        if currentWeapon then
+            return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+        end
+
+        return
+    end
+
+	if currentWeapon and currentWeapon.timer ~= 0 then
+        if not currentWeapon.timer or currentWeapon.timer - GetGameTimer() > 100 then return end
+
+        DisablePlayerFiring(cache.playerId, true)
+    end
+
+    if invOpen and data.close then client.closeInventory() end
+
+    usingItem = true
+    ---@type boolean?
+    result = lib.callback.await('ox_inventory:useItem', 200, data.name, data.slot, slotData.metadata, noAnim)
+
+	if result and cb then
+		local success, response = pcall(cb, result and slotData)
+
+		if not success and response then
+			warn(('^1An error occurred while calling item "%s" callback!\n^1SCRIPT ERROR: %s^0'):format(slotData.name, response))
+		end
+	end
+
+    if result then
+        TriggerEvent('ox_inventory:usedItem', slotData.name, slotData.slot, next(slotData.metadata) and slotData.metadata)
+    end
+
+	Wait(500)
+    usingItem = false
+end
+
+AddEventHandler('ox_inventory:usedItem', function(name, slot, metadata)
+    TriggerServerEvent('ox_inventory:usedItemInternal', slot)
+end)
+
+AddEventHandler('ox_inventory:item', useItem)
+exports('useItem', useItem)
+
+---@param slot number
+---@return boolean?
+local function useSlot(slot, noAnim, dings) --dings added by Holger
+	local item = PlayerData.inventory[slot]
+	if not item then return end
+
+	local data = Items[item.name]
+	if not data then return end
+
+	if canUseItem(data.ammo and true) then
+		if data.component and not currentWeapon then
+			return lib.notify({ id = 'weapon_hand_required', type = 'error', description = locale('weapon_hand_required') })
+		end
+
+		local durability = item.metadata.durability --[[@as number?]]
+		local consume = data.consume --[[@as number?]]
+		local label = item.metadata.label or item.label --[[@as string]]
+
+		-- Naive durability check to get an early exit
+		-- People often don't call the 'useItem' export and then complain about "broken" items being usable
+		-- This won't work with degradation since we need access to os.time on the server
+		if durability and durability <= 100 and consume then
+			if durability <= 0 then
+				return lib.notify({ type = 'error', description = locale('no_durability', label) })
+			elseif consume ~= 0 and consume < 1 and durability < consume * 100 then
+				return lib.notify({ type = 'error', description = locale('not_enough_durability', label) })
+			end
+		end
+
+		data.slot = slot
+
+		if item.metadata.container then
+			return client.openInventory('container', item.slot)
+		elseif data.client then
+			if invOpen and data.close then client.closeInventory() end
+
+			if data.export then
+				return data.export(data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			elseif data.client.event then -- re-add it, so I don't need to deal with morons taking screenshots of errors when using trigger event
+				return TriggerEvent(data.client.event, data, {name = item.name, slot = item.slot, metadata = item.metadata})
+			end
+		end
+
+		if data.effect then
+			data:effect({name = item.name, slot = item.slot, metadata = item.metadata})
+		elseif data.weapon then
+			if not plyState.canUseWeapons then return end
+			if EnableWeaponWheel then -- if by Holger
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+
+					if dings then -- if by Holger
+						currentWeapon =  Weapon.Disarm(currentWeapon,false,true)
+					else					
+						currentWeapon =  Weapon.Disarm(currentWeapon)
+					end
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			else
+				if IsCinematicCamRendering() then SetCinematicModeActive(false) end
+
+				if currentWeapon then
+					if not currentWeapon.timer or currentWeapon.timer ~= 0 then return end
+
+					local weaponSlot = currentWeapon.slot
+					
+					currentWeapon =  Weapon.Disarm(currentWeapon)
+
+					if weaponSlot == data.slot then return end
+				end
+
+				GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+				SetCurrentPedWeapon(playerPed, data.hash, false)
+
+				if data.hash ~= GetSelectedPedWeapon(playerPed) then
+					lib.print.info(('failed to equip %s (cause unknown)'):format(item.name))
+					return lib.notify({ type = 'error', description = locale('cannot_use', data.label) })
+				end
+
+				RemoveWeaponFromPed(cache.ped, data.hash)
+
+				useItem(data, function(result)
+					if result then
+						local sleep
+						currentWeapon, sleep = Weapon.Equip(item, data, noAnim)
+
+						if sleep then Wait(sleep) end
+					end
+				end, noAnim)
+			end
+		elseif currentWeapon then
+			if data.ammo then
+				if Utils.Waffensyncaus or currentWeapon.metadata.durability <= 0 then return end ----Holger replaced : EnableWeaponWheel to Utils.Waffensyncaus
+
+				local clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+				local currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+				local _, maxAmmo = GetMaxAmmo(playerPed, currentWeapon.hash)
+
+				if maxAmmo < clipSize then clipSize = maxAmmo end
+
+				if currentAmmo == clipSize then return end
+
+				useItem(data, function(resp)
+					if not resp or resp.name ~= currentWeapon?.ammo then return end
+
+					if currentWeapon.metadata.specialAmmo ~= resp.metadata.type and type(currentWeapon.metadata.specialAmmo) == 'string' then
+						local clipComponentKey = ('%s_CLIP'):format(Items[currentWeapon.name].model:gsub('WEAPON_', 'COMPONENT_'))
+						local specialClip = ('%s_%s'):format(clipComponentKey, (resp.metadata.type or currentWeapon.metadata.specialAmmo):upper())
+
+						if type(resp.metadata.type) == 'string' then
+							if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+								if not DoesWeaponTakeWeaponComponent(currentWeapon.hash, specialClip) then
+									warn('cannot use clip with this weapon')
+									return
+								end
+
+								local defaultClip = ('%s_01'):format(clipComponentKey)
+
+								if not HasPedGotWeaponComponent(playerPed, currentWeapon.hash, defaultClip) then
+									warn('cannot use clip with currently equipped clip')
+									return
+								end
+
+								if currentAmmo > 0 then
+									warn('cannot mix special ammo with base ammo')
+									return
+								end
+
+								currentWeapon.metadata.specialAmmo = resp.metadata.type
+
+								GiveWeaponComponentToPed(playerPed, currentWeapon.hash, specialClip)
+							end
+						elseif HasPedGotWeaponComponent(playerPed, currentWeapon.hash, specialClip) then
+							if currentAmmo > 0 then
+								warn('cannot mix special ammo with base ammo')
+								return
+							end
+
+							currentWeapon.metadata.specialAmmo = nil
+
+							RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, specialClip)
+						end
+					end
+
+					if maxAmmo > clipSize then
+						clipSize = GetMaxAmmoInClip(playerPed, currentWeapon.hash, true)
+					end
+
+					currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+					local missingAmmo = clipSize - currentAmmo
+					local addAmmo = resp.count > missingAmmo and missingAmmo or resp.count
+					local newAmmo = currentAmmo + addAmmo
+
+					if newAmmo == currentAmmo then return end
+
+                    AddAmmoToPed(playerPed, currentWeapon.hash, addAmmo)
+
+					if cache.vehicle then
+						if cache.seat > -1 or IsVehicleStopped(cache.vehicle) then
+							TaskReloadWeapon(playerPed, true)
+                        else
+                            -- This is a hacky solution for forcing ammo to properly load into the
+                            -- weapon clip while driving; without it, ammo will be added but won't
+                            -- load until the player stops doing anything. i.e. if you keep shooting,
+                            -- the weapon will not reload until the clip empties.
+                            -- And yes - for some reason RefillAmmoInstantly needs to run in a loop.
+                            lib.waitFor(function()
+                                RefillAmmoInstantly(playerPed)
+
+                                local _, ammo = GetAmmoInClip(playerPed, currentWeapon.hash)
+                                return ammo == newAmmo or nil
+                            end)
+                        end
+					else
+						Wait(100)
+						MakePedReload(playerPed)
+
+						SetTimeout(100, function()
+							while IsPedReloading(playerPed) do
+								DisableControlAction(0, 22, true)
+								Wait(0)
+							end
+						end)
+					end
+
+					lib.callback.await('ox_inventory:updateWeapon', false, 'load', newAmmo, false, currentWeapon.metadata.specialAmmo)
+				end)
+			elseif data.component then
+				local components = data.client.component
+
+                if not components then return end
+
+				local componentType = data.type
+				local weaponComponents = PlayerData.inventory[currentWeapon.slot].metadata.components
+
+				-- Checks if the weapon already has the same component type attached
+				for componentIndex = 1, #weaponComponents do
+					if componentType == Items[weaponComponents[componentIndex]].type then
+						return lib.notify({ id = 'component_slot_occupied', type = 'error', description = locale('component_slot_occupied', componentType) })
+					end
+				end
+
+				for i = 1, #components do
+					local component = components[i]
+
+					if DoesWeaponTakeWeaponComponent(currentWeapon.hash, component) then
+						if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+							lib.notify({ id = 'component_has', type = 'error', description = locale('component_has', label) })
+						else
+							useItem(data, function(data)
+								if data then
+									local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', tostring(data.slot), currentWeapon.slot)
+
+									if success then
+										GiveWeaponComponentToPed(playerPed, currentWeapon.hash, component)
+										TriggerEvent('ox_inventory:updateWeaponComponent', 'added', component, data.name)
+									end
+								end
+							end)
+						end
+						return
+					end
+				end
+				lib.notify({ id = 'component_invalid', type = 'error', description = locale('component_invalid', label) })
+			elseif data.allowArmed then
+				useItem(data)
+            else
+                return lib.notify({ id = 'cannot_perform', type = 'error', description = locale('cannot_perform') })
+			end
+		elseif not data.ammo and not data.component then
+			useItem(data)
+		end
+    end
+end
+exports('useSlot', useSlot)
+
+---@param id number
+---@param slot number
+local function useButton(id, slot)
+	if PlayerData.loaded and not invBusy and not lib.progressActive() then
+		local item = PlayerData.inventory[slot]
+		if not item then return end
+
+		local data = Items[item.name]
+		local buttons = data?.buttons
+
+		if buttons and buttons[id]?.action then
+			buttons[id].action(slot)
+		end
+	end
+end
+
+local function openNearbyInventory() client.openInventory('player') end
+
+exports('openNearbyInventory', openNearbyInventory)
+
+local currentInstance
+local playerCoords
+local Shops = require 'modules.shops.client'
+
+---@todo remove or replace when the bridge module gets restructured
+function OnPlayerData(key, val)
+	if key ~= 'groups' and key ~= 'ped' and key ~= 'dead' then return end
+
+	if key == 'groups' then
+		Inventory.Stashes()
+		Inventory.Evidence()
+		Shops.refreshShops()
+	elseif key == 'dead' and val then
+		currentWeapon = Weapon.Disarm(currentWeapon)
+		client.closeInventory()
+	end
+
+	Utils.WeaponWheel()
+end
+
+-- People consistently ignore errors when one of the "modules" failed to load
+if not Utils or not Weapon or not Items or not Inventory then return end
+
+local invHotkeys = false
+
+---@type function?
+local function registerCommands()
+	if client.enablestealcommand then
+		RegisterCommand('steal', openNearbyInventory, false)
+	end
+
+	local function openGlovebox(vehicle)
+		if not IsPedInAnyVehicle(playerPed, false) or not NetworkGetEntityIsNetworked(vehicle) then return end
+
+		if IsEntityDead(vehicle) then return end
+
+		local vehicleHash = GetEntityModel(vehicle)
+		local vehicleClass = GetVehicleClass(vehicle)
+		local checkVehicle = Vehicles.Storage[vehicleHash]
+
+		-- No storage or no glovebox
+		if (checkVehicle == 0 or checkVehicle == 2) or (not Vehicles.glovebox[vehicleClass] and not Vehicles.glovebox.models[vehicleHash]) then return end
+
+		local isOpen = client.openInventory('glovebox', { netid = NetworkGetNetworkIdFromEntity(vehicle) })
+
+		if isOpen then
+			currentInventory.entity = vehicle
+		end
+	end
+
+	local primary = lib.addKeybind({
+		name = 'inv',
+		description = locale('open_player_inventory'),
+		defaultKey = client.keys[1],
+		onPressed = function()
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local closest = lib.points.getClosestPoint()
+
+			if closest and closest.currentDistance < 1.2 and (not closest.instance or closest.instance == currentInstance) then
+				if closest.inv == 'crafting' then
+					return client.openInventory('crafting', { id = closest.id, index = closest.index })
+				elseif closest.inv ~= 'license' and closest.inv ~= 'policeevidence' then
+					return client.openInventory(closest.inv or 'drop', { id = closest.invId, type = closest.type })
+				end
+			end
+
+			return client.openInventory()
+		end
+	})
+
+	lib.addKeybind({
+		name = 'inv2',
+		description = locale('open_secondary_inventory'),
+		defaultKey = client.keys[2],
+		onPressed = function(self)
+            if primary:getCurrentKey() == self:getCurrentKey() then
+                return warn(("secondary inventory keybind '%s' disabled (keybind cannot match primary inventory keybind)"):format(self:getCurrentKey()))
+            end
+
+			if invOpen then
+				return client.closeInventory()
+			end
+
+			if invBusy or not canOpenInventory() then
+				return lib.notify({ id = 'inventory_player_access', type = 'error', description = locale('inventory_player_access') })
+			end
+
+			if StashTarget then
+				return client.openInventory('stash', StashTarget)
+			end
+
+			if cache.vehicle then
+				return openGlovebox(cache.vehicle)
+			end
+
+			local entity, entityType = Utils.Raycast(2|16)
+
+			if not entity then return end
+
+			if not shared.target and entityType == 3 then
+				local model = GetEntityModel(entity)
+
+				if Inventory.Dumpsters:includes(model) then
+					return Inventory.OpenDumpster(entity)
+				end
+			end
+
+			if entityType ~= 2 then return end
+
+			Inventory.OpenTrunk(entity)
+		end
+	})
+
+	lib.addKeybind({
+		name = 'reloadweapon',
+		description = locale('reload_weapon'),
+		defaultKey = 'r',
+		onPressed = function(self)
+			if not currentWeapon or Utils.Waffensyncaus or not canUseItem(true) then return end ---Holger changed EnableWeaponWheel to Utils.Waffensyncaus
+
+			if currentWeapon.ammo then
+				if currentWeapon.metadata.durability > 0 then
+					local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+					if slotId then
+						useSlot(slotId)
+					end
+				else
+					lib.notify({ id = 'no_durability', type = 'error', description = locale('no_durability', currentWeapon.label) })
+				end
+			end
+		end
+	})
+
+	lib.addKeybind({
+		name = 'hotbar',
+		description = locale('disable_hotbar'),
+		defaultKey = client.keys[3],
+		onPressed = function()
+			if (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() or lib.progressActive() then return end --Holger added: and not HotbarundWeaponWheel
+			SendNUIMessage({ action = 'toggleHotbar' })
+		end
+	})
+
+	for i = 1, 5 do
+		lib.addKeybind({
+			name = ('hotkey%s'):format(i),
+			description = locale('use_hotbar', i),
+			defaultKey = tostring(i),
+			onPressed = function()
+				if invOpen or (EnableWeaponWheel and not HotbarundWeaponWheel) or not invHotkeys or IsNuiFocused() then return end --Holger added: and not HotbarundWeaponWheel
+				useSlot(i)
+			end
+		})
+	end
+
+	registerCommands = nil
+end
+
+function client.closeInventory()
+	if not client.interval then return end
+
+	if invOpen then
+		invOpen = nil
+		SetNuiFocus(false, false)
+		SetNuiFocusKeepInput(false)
+		Utils.blurOut()
+		closeTrunk()
+		SendNUIMessage({ action = 'closeInventory' })
+		SetInterval(client.interval, 200)
+		Wait(200)
+
+		if invOpen ~= nil then return end
+
+		TriggerServerEvent('ox_inventory:closeInventory')
+
+		currentInventory = defaultInventory
+		plyState.invOpen = false
+		defaultInventory.coords = nil
+	end
+end
+
+RegisterNetEvent('ox_inventory:closeInventory', client.closeInventory)
+exports('closeInventory', client.closeInventory)
+
+---@param data updateSlot[]
+---@param weight number
+local function updateInventory(data, weight)
+	local changes = {}
+    ---@type table<string, number>
+	local itemCount = {}
+
+	for i = 1, #data do
+		local v = data[i]
+
+		if not v.inventory or v.inventory == cache.serverId then
+			v.inventory = 'player'
+			local item = v.item
+
+			if currentWeapon?.slot == item?.slot then
+                if item.metadata then
+				    currentWeapon.metadata = item.metadata
+				    TriggerEvent('ox_inventory:currentWeapon', currentWeapon)
+                else
+                    currentWeapon = Weapon.Disarm(currentWeapon, true)
+                end
+			end
+
+			local curItem = PlayerData.inventory[item.slot]
+
+			if curItem and curItem.name then  -- if changed by Holger
+				if itemCount[curItem.name] == nil then
+					itemCount[curItem.name] = {}
+				end
+				itemCount[curItem.name].count = (itemCount[curItem.name].count or 0) - curItem.count
+				itemCount[curItem.name].slot = item.slot
+			end
+
+			if item.count then	-- if changed by Holger
+				if itemCount[item.name] == nil then
+					itemCount[item.name] = {}
+				end
+				itemCount[item.name].count = (itemCount[item.name].count or 0) + item.count
+				itemCount[item.name].slot = item.slot
+			end
+
+			changes[item.slot] = item.count and item or false
+			if not item.count then item.name = nil end
+			PlayerData.inventory[item.slot] = item.name and item or nil
+		end
+	end
+
+	SendNUIMessage({ action = 'refreshSlots', data = { items = data, itemCount = itemCount} })
+
+    if weight ~= PlayerData.weight then client.setPlayerData('weight', weight) end
+
+	for itemName, dings in pairs(itemCount) do --changed count to dings	Holger
+		local item = Items(itemName)
+
+        if item then
+            item.count += dings.count --added dings.	Holger
+
+			------------Holgers Anpassungen
+			if string.sub(item.name,1,7) =="WEAPON_"  and item.name ~= "WEAPON_PETROLCAN"  and item.count  >0 and not HasPedGotWeapon(cache.ped,item.name,false) then
+				local hash = GetHashKey(item.name)
+				Waffencache[hash] = {}
+				Waffencache[hash].name = item.name
+				Waffencache[hash].slot = dings.slot
+				Waffencache[hash].hash = hash
+				
+				RemoveWeaponFromPed(cache.ped,item.name)
+				GiveWeaponToPed(cache.ped,item.name,1,false,false) 
+			elseif string.sub(item.name,1,7) =="WEAPON_" and item.count  == 0 then
+				local loeschdas
+				for k,v in pairs(Waffencache) do
+					if v.name ==item.name then
+						loeschdas = k
+					end
+				end
+				Waffencache[loeschdas] = nil
+				if currentWeapon and currentWeapon.name == item.name then
+					currentWeapon = Weapon.Disarm(currentWeapon, false,"lurch")
+				else
+					RemoveWeaponFromPed(cache.ped,item.name)
+				end 
+			end
+
+			-----Holgers Anpassungen ende
+
+            TriggerEvent('ox_inventory:itemCount', item.name, item.count)
+
+            if dings.count < 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:removeInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.remove then
+                    item.client.remove(item.count)
+                end
+            elseif dings.count > 0 then --added dings.	Holger
+                if shared.framework == 'esx' then
+                    TriggerEvent('esx:addInventoryItem', item.name, item.count)
+                end
+
+                if item.client?.add then
+                    item.client.add(item.count)
+                end
+            end
+        end
+	end
+
+	client.setPlayerData('inventory', PlayerData.inventory)
+	TriggerEvent('ox_inventory:updateInventory', changes)
+end
+
+RegisterNetEvent('ox_inventory:updateSlots', function(items, weights)
+	if source ~= '' and next(items) then updateInventory(items, weights) end
+end)
+
+RegisterNetEvent('ox_inventory:inventoryReturned', function(data)
+	if source == '' then return end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	lib.notify({ description = locale('items_returned') })
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for _, slotData in pairs(data[1]) do
+		num += 1
+		items[num] = { item = slotData, inventory = cache.serverId }
+	end
+
+	updateInventory(items, data[3])
+end)
+
+RegisterNetEvent('ox_inventory:inventoryConfiscated', function(message)
+	if source == '' then return end
+	if message then lib.notify({ description = locale('items_confiscated') }) end
+	if currentWeapon then currentWeapon = Weapon.Disarm(currentWeapon) end
+
+	client.closeInventory()
+
+	local num, items = 0, {}
+
+	for slot in pairs(PlayerData.inventory) do
+		num += 1
+		items[num] = { item = { slot = slot }, inventory = cache.serverId }
+	end
+
+	updateInventory(items, 0)
+end)
+
+
+---@param point CPoint
+local function nearbyDrop(point)
+	if not point.instance or point.instance == currentInstance then
+        DrawMarker(client.dropmarker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, client.dropmarker.scale[1], client.dropmarker.scale[2], client.dropmarker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        client.dropmarker.colour[1], client.dropmarker.colour[2], client.dropmarker.colour[3], 222, false, false, 0, true, false, false, false)
+    end
+end
+
+---@param point CPoint
+local function onEnterDrop(point)
+	if not point.instance or point.instance == currentInstance and not point.entity then
+		local model = point.model or client.dropmodel
+
+        -- Prevent breaking inventory on invalid point.model instead use default client.dropmodel
+        if not IsModelValid(model) and not IsModelInCdimage(model) then
+            model = client.dropmodel
+        end
+		lib.requestModel(model)
+
+		local entity = CreateObject(model, point.coords.x, point.coords.y, point.coords.z, false, true, true)
+
+		SetModelAsNoLongerNeeded(model)
+		PlaceObjectOnGroundProperly(entity)
+		FreezeEntityPosition(entity, true)
+		SetEntityCollision(entity, false, true)
+
+		point.entity = entity
+	end
+end
+
+local function onExitDrop(point)
+	local entity = point.entity
+
+	if entity then
+		Utils.DeleteEntity(entity)
+		point.entity = nil
+	end
+end
+
+local function createDrop(dropId, data)
+	local point = lib.points.new({
+		coords = data.coords,
+		distance = 16,
+		invId = dropId,
+		instance = data.instance,
+		model = data.model
+	})
+
+	if point.model or client.dropprops then
+		point.distance = 30
+		point.onEnter = onEnterDrop
+		point.onExit = onExitDrop
+	else
+		point.nearby = nearbyDrop
+	end
+
+	client.drops[dropId] = point
+end
+
+RegisterNetEvent('ox_inventory:createDrop', function(dropId, data, owner, slot)
+	if client.drops then
+		createDrop(dropId, data)
+	end
+
+	if owner == cache.serverId then
+		if currentWeapon?.slot == slot then
+			currentWeapon = Weapon.Disarm(currentWeapon)
+		end
+
+		if invOpen and #(GetEntityCoords(playerPed) - data.coords) <= 1 then
+			if not cache.vehicle then
+				client.openInventory('drop', dropId)
+			else
+				SendNUIMessage({
+					action = 'setupInventory',
+					data = { rightInventory = currentInventory }
+				})
+			end
+		end
+	end
+end)
+
+RegisterNetEvent('ox_inventory:removeDrop', function(dropId)
+	if client.drops then
+		local point = client.drops[dropId]
+
+		if point then
+			client.drops[dropId] = nil
+			point:remove()
+
+			if point.entity then Utils.DeleteEntity(point.entity) end
+		end
+	end
+end)
+
+---@type function?
+local function setStateBagHandler(stateId)
+	AddStateBagChangeHandler('invOpen', stateId, function(_, _, value)
+		invOpen = value
+	end)
+
+	AddStateBagChangeHandler('invBusy', stateId, function(_, _, value)
+		invBusy = value
+	end)
+
+    AddStateBagChangeHandler('canUseWeapons', stateId, function(_, _, value)
+        if not value and currentWeapon then
+            currentWeapon = Weapon.Disarm(currentWeapon)
+        end
+    end)
+
+	AddStateBagChangeHandler('instance', stateId, function(_, _, value)
+		currentInstance = value
+
+		if client.drops then
+			-- Iterate over known drops and remove any points in a different instance (ignoring no instance)
+			for dropId, point in pairs(client.drops) do
+				if point.instance then
+					if point.instance ~= value then
+						if point.entity then
+							Utils.DeleteEntity(point.entity)
+							point.entity = nil
+						end
+
+						point:remove()
+					else
+						-- Recreate the drop using data from the old point
+						createDrop(dropId, point)
+					end
+				end
+			end
+		end
+	end)
+
+	AddStateBagChangeHandler('dead', stateId, function(_, _, value)
+		Utils.WeaponWheel()
+		PlayerData.dead = value
+	end)
+
+	AddStateBagChangeHandler('invHotkeys', stateId, function(_, _, value)
+		invHotkeys = value
+	end)
+
+	setStateBagHandler = nil
+end
+
+RegisterNetEvent('txcl:heal', function()
+    if source == '' then return end
+
+    PlayerData.dead = false
+end)
+
+lib.onCache('seat', function(seat)
+	if seat then
+		local hasWeapon = GetCurrentPedVehicleWeapon(cache.ped)
+
+		if hasWeapon then
+			return Utils.WeaponWheel(true)
+		end
+	end
+
+	Utils.WeaponWheel(false)
+end)
+
+lib.onCache('vehicle', function()
+	if invOpen and (not currentInventory.entity or currentInventory.entity == cache.vehicle) then
+		return client.closeInventory()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:setPlayerInventory', function(currentDrops, inventory, weight, player)
+	if source == '' then return end
+
+    ---@class PlayerData
+    ---@field inventory table<number, SlotWithItem?>
+    ---@field weight number
+    ---@field groups table<string, number>
+	PlayerData = player
+	PlayerData.id = cache.playerId
+	PlayerData.source = cache.serverId
+    PlayerData.maxWeight = shared.playerweight
+
+	setmetatable(PlayerData, {
+		__index = function(self, key)
+			if key == 'ped' then
+				return PlayerPedId()
+			end
+		end
+	})
+
+	if setStateBagHandler then setStateBagHandler(('player:%s'):format(cache.serverId)) end
+
+	local ItemData = table.create(0, #Items)
+
+	for _, v in pairs(Items --[[@as table<string, OxClientItem>]]) do
+		local buttons = v.buttons and {} or nil
+
+		if buttons then
+			for i = 1, #v.buttons do
+				buttons[i] = {label = v.buttons[i].label, group = v.buttons[i].group}
+			end
+		end
+
+		ItemData[v.name] = {
+			label = v.label,
+			stack = v.stack,
+			close = v.close,
+			count = 0,
+			description = v.description,
+			buttons = buttons,
+			ammoName = v.ammoname,
+			image = v.client?.image
+		}
+	end
+
+	for _, data in pairs(inventory) do
+		local item = Items[data.name]
+
+		if item then
+			item.count += data.count
+			ItemData[data.name].count += data.count
+			local add = item.client?.add
+
+			if add then
+				add(item.count)
+			end
+		end
+	end
+
+	local phone = Items.phone
+
+	if phone and phone.count < 1 then
+		pcall(function()
+			return exports.npwd:setPhoneDisabled(true)
+		end)
+	end
+
+	client.setPlayerData('inventory', inventory)
+	client.setPlayerData('weight', weight)
+	currentWeapon = nil
+	Weapon.ClearAll()
+
+	local uiLocales = {}
+	local locales = lib.getLocales()
+
+	for k, v in pairs(locales) do
+		if k:find('^ui_')then
+			uiLocales[k] = v
+		end
+	end
+
+	uiLocales['$'] = locales['$']
+	uiLocales.ammo_type = locales.ammo_type
+
+	client.drops = currentDrops
+
+	for dropId, data in pairs(currentDrops) do
+		createDrop(dropId, data)
+	end
+
+	local hasTextUi
+	local uiOptions = { icon = 'fa-id-card' }
+
+	---@param point CPoint
+	local function nearbyLicense(point)
+		---@diagnostic disable-next-line: param-type-mismatch
+		DrawMarker(2, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.2, 0.15, 30, 150, 30, 222, false, false, 0, true, false, false, false)
+
+		if point.isClosest and point.currentDistance < 1.2 then
+			if not hasTextUi then
+				hasTextUi = point
+				lib.showTextUI(point.message, uiOptions)
+			end
+
+			if IsControlJustReleased(0, 38) then
+				lib.callback('ox_inventory:buyLicense', 1000, function(success, message)
+					if success ~= nil then
+						lib.notify({
+							id = message,
+							type = success == false and 'error' or 'success',
+							description = locale(message, locale('license', point.type:gsub("^%l", string.upper)))
+						})
+					end
+				end, point.invId)
+			end
+		elseif hasTextUi == point then
+			hasTextUi = false
+			lib.hideTextUI()
+		end
+	end
+
+	for id, data in pairs(lib.load('data.licenses') or {}) do
+		lib.points.new({
+			coords = data.coords,
+			distance = 16,
+			inv = 'license',
+			type = data.name,
+			price = data.price,
+			invId = id,
+			nearby = nearbyLicense,
+			message = ('**%s**  \n%s'):format(locale('purchase_license', data.name), locale('interact_prompt', GetControlInstructionalButton(0, 38, true):sub(3)))
+		})
+	end
+
+	while not client.uiLoaded do Wait(50) end
+
+	SendNUIMessage({
+		action = 'init',
+		data = {
+			locale = uiLocales,
+			items = ItemData,
+			leftInventory = {
+				id = cache.playerId,
+				slots = shared.playerslots,
+				items = PlayerData.inventory,
+				maxWeight = shared.playerweight,
+			},
+			imagepath = client.imagepath
+		}
+	})
+
+	PlayerData.loaded = true
+
+	if not client.disablesetupnotification then
+		lib.notify({ description = locale('inventory_setup') })
+	end
+
+	Shops.refreshShops()
+	Inventory.Stashes()
+	Inventory.Evidence()
+
+	if registerCommands then registerCommands() end
+
+	TriggerEvent('ox_inventory:updateInventory', PlayerData.inventory)
+
+	client.interval = SetInterval(function()
+        local canSteal = canOpenTarget(playerPed)
+
+        if canSteal ~= plyState.canSteal then
+            plyState:set('canSteal', canSteal, true)
+        end
+
+		if invOpen == false then
+			playerCoords = GetEntityCoords(playerPed)
+
+			if currentWeapon and IsPedUsingActionMode(playerPed) then
+				SetPedUsingActionMode(playerPed, false, -1, 'DEFAULT_ACTION')
+			end
+
+		elseif invOpen == true then
+			if not canOpenInventory() then
+				client.closeInventory()
+			else
+				playerCoords = GetEntityCoords(playerPed)
+
+				if not currentInventory.ignoreSecurityChecks then
+                    local maxDistance = (currentInventory.distance or currentInventory.type == 'stash' and 4.8 or 1.8) + 0.2
+
+					if currentInventory.type == 'otherplayer' then
+						local id = GetPlayerFromServerId(currentInventory.id --[[@as number]])
+						local ped = GetPlayerPed(id)
+						local pedCoords = GetEntityCoords(ped)
+
+						if not id or #(playerCoords - pedCoords) > maxDistance or (not client.hasGroup(shared.police) and not Player(currentInventory.id).state.canSteal) then
+							client.closeInventory()
+							lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+						else
+							TaskTurnPedToFaceCoord(playerPed, pedCoords.x, pedCoords.y, pedCoords.z, 50)
+						end
+
+					elseif currentInventory.coords and (#(playerCoords - currentInventory.coords) > maxDistance or canSteal) then
+						client.closeInventory()
+						lib.notify({ id = 'inventory_lost_access', type = 'error', description = locale('inventory_lost_access') })
+					end
+				end
+			end
+		end
+
+		if client.parachute and GetPedParachuteState(playerPed) ~= -1 then
+			Utils.DeleteEntity(client.parachute[1])
+			client.parachute = false
+		end
+
+		if EnableWeaponWheel then return end
+
+		local weaponHash = GetSelectedPedWeapon(playerPed)
+
+		if currentWeapon then
+			if weaponHash ~= currentWeapon.hash and currentWeapon.timer then
+				local weaponCount = Items[currentWeapon.name]?.count
+
+				if weaponCount > 0 then
+					SetCurrentPedWeapon(playerPed, currentWeapon.hash, true)
+					SetAmmoInClip(playerPed, currentWeapon.hash, currentWeapon.metadata.ammo)
+					SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+
+					weaponHash = GetSelectedPedWeapon(playerPed)
+				end
+
+				if weaponHash ~= currentWeapon.hash then
+                    lib.print.info(('%s was forcibly unequipped (caused by game behaviour or another resource)'):format(currentWeapon.name))
+					currentWeapon = Weapon.Disarm(currentWeapon, true)
+				end
+			end
+		elseif client.weaponmismatch and not client.ignoreweapons[weaponHash] then
+			local weaponType = GetWeapontypeGroup(weaponHash)
+
+			if weaponType ~= 0 and weaponType ~= `GROUP_UNARMED` then
+				Weapon.Disarm(currentWeapon, true)
+			end
+		end
+	end, 200)
+
+	local playerId = cache.playerId
+	local EnableKeys = client.enablekeys
+	local DisablePlayerVehicleRewards = DisablePlayerVehicleRewards
+	local DisableAllControlActions = DisableAllControlActions
+	local HideHudAndRadarThisFrame = HideHudAndRadarThisFrame
+	local EnableControlAction = EnableControlAction
+	local DisablePlayerFiring = DisablePlayerFiring
+	local HudWeaponWheelIgnoreSelection = HudWeaponWheelIgnoreSelection
+	local DisableControlAction = DisableControlAction
+	local IsPedShooting = IsPedShooting
+	local IsControlJustReleased = IsControlJustReleased
+
+	client.tick = SetInterval(function()
+		DisablePlayerVehicleRewards(playerId)
+
+		if invOpen then
+			DisableAllControlActions(0)
+			HideHudAndRadarThisFrame()
+
+			for i = 1, #EnableKeys do
+				EnableControlAction(0, EnableKeys[i], true)
+			end
+
+			if currentInventory.type == 'drop' or currentInventory.type == 'newdrop' then
+				EnableControlAction(0, 30, true)
+				EnableControlAction(0, 31, true)
+			end
+		else
+			if invBusy then
+				DisableControlAction(0, 23, true)
+				DisableControlAction(0, 36, true)
+			end
+
+			if usingItem or invOpen or IsPedCuffed(playerPed) then
+				DisablePlayerFiring(playerId, true)
+			end
+
+			if not EnableWeaponWheel then
+				HudWeaponWheelIgnoreSelection()
+				DisableControlAction(0, 37, true)
+			end
+
+			if currentWeapon and currentWeapon.timer then
+				DisableControlAction(0, 80, true)
+				DisableControlAction(0, 140, true)
+
+				if currentWeapon.metadata.durability <= 0 or not currentWeapon.timer then
+					DisablePlayerFiring(playerId, true)
+				elseif client.aimedfiring and not currentWeapon.melee and currentWeapon.group ~= `GROUP_PETROLCAN` and not IsPlayerFreeAiming(playerId) then
+					DisablePlayerFiring(playerId, true)
+				end
+
+				local weaponAmmo = currentWeapon.metadata.ammo
+
+				if not invBusy and currentWeapon.timer ~= 0 and currentWeapon.timer < GetGameTimer() then
+					currentWeapon.timer = 0
+
+					if weaponAmmo then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'ammo', weaponAmmo)
+
+						if client.autoreload and currentWeapon.ammo and GetAmmoInPedWeapon(playerPed, currentWeapon.hash) == 0 then
+							local slotId = Inventory.GetSlotIdWithItem(currentWeapon.ammo, { type = currentWeapon.metadata.specialAmmo }, false)
+
+							if slotId then
+								CreateThread(function() useSlot(slotId) end)
+							end
+						end
+
+					elseif currentWeapon.metadata.durability then
+						TriggerServerEvent('ox_inventory:updateWeapon', 'melee', currentWeapon.melee)
+						currentWeapon.melee = 0
+					end
+				elseif weaponAmmo then
+					if IsPedShooting(playerPed) then
+						local currentAmmo
+						local durabilityDrain = Items[currentWeapon.name].durability
+
+						if currentWeapon.group == `GROUP_PETROLCAN` or currentWeapon.group == `GROUP_FIREEXTINGUISHER` then
+							currentAmmo = weaponAmmo - durabilityDrain < 0 and 0 or weaponAmmo - durabilityDrain
+							currentWeapon.metadata.durability = currentAmmo
+							currentWeapon.metadata.ammo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+
+							if currentAmmo <= 0 then
+								SetPedInfiniteAmmo(playerPed, false, currentWeapon.hash)
+							end
+						else
+							currentAmmo = GetAmmoInPedWeapon(playerPed, currentWeapon.hash)
+
+							if currentAmmo < weaponAmmo then
+								currentAmmo = (weaponAmmo < currentAmmo) and 0 or currentAmmo
+								currentWeapon.metadata.ammo = currentAmmo
+								currentWeapon.metadata.durability = currentWeapon.metadata.durability - (durabilityDrain * math.abs((weaponAmmo or 0.1) - currentAmmo))
+							end
+						end
+
+						if currentAmmo <= 0 then
+							if cache.vehicle then
+								TaskSwapWeapon(playerPed, true)
+							end
+
+							currentWeapon.timer = GetGameTimer() + 200
+						else currentWeapon.timer = GetGameTimer() + (GetWeaponTimeBetweenShots(currentWeapon.hash) * 1000) + 100 end
+					end
+				elseif currentWeapon.throwable then
+					if not invBusy and IsControlPressed(0, 24) then
+						invBusy = 1
+
+						CreateThread(function()
+							local weapon = currentWeapon
+
+							while currentWeapon and (not IsPedWeaponReadyToShoot(cache.ped) or IsDisabledControlPressed(0, 24)) and GetSelectedPedWeapon(playerPed) == weapon.hash do
+								Wait(0)
+							end
+
+							if GetSelectedPedWeapon(playerPed) == weapon.hash then Wait(700) end
+
+							while IsPedPlantingBomb(playerPed) do Wait(0) end
+
+							TriggerServerEvent('ox_inventory:updateWeapon', 'throw', nil, weapon.slot)
+							plyState:set('invBusy', false, true)
+
+							currentWeapon = nil
+
+							RemoveWeaponFromPed(playerPed, weapon.hash)
+							TriggerEvent('ox_inventory:currentWeapon')
+						end)
+					end
+				elseif currentWeapon.melee and IsControlJustReleased(0, 24) and IsPedPerformingMeleeAction(playerPed) then
+					currentWeapon.melee += 1
+					currentWeapon.timer = GetGameTimer() + 200
+				end
+			end
+		end
+	end)
+
+	plyState:set('invBusy', false, true)
+	plyState:set('invOpen', false, false)
+	plyState:set('invHotkeys', true, false)
+	plyState:set('canUseWeapons', true, false)
+	collectgarbage('collect')
+end)
+
+AddEventHandler('onResourceStop', function(resourceName)
+	if shared.resource == resourceName then
+		client.onLogout()
+	end
+end)
+
+RegisterNetEvent('ox_inventory:viewInventory', function(left, right)
+	if source == '' then return end
+
+	plyState.invOpen = true
+
+	SetInterval(client.interval, 100)
+	SetNuiFocus(true, true)
+	SetNuiFocusKeepInput(true)
+	closeTrunk()
+
+	if client.screenblur then Utils.blurIn() end
+
+	currentInventory = right or defaultInventory
+	currentInventory.ignoreSecurityChecks = true
+    currentInventory.type = 'inspect'
+	left.items = PlayerData.inventory
+	left.groups = PlayerData.groups
+
+	SendNUIMessage({
+		action = 'setupInventory',
+		data = {
+			leftInventory = left,
+			rightInventory = currentInventory
+		}
+	})
+end)
+
+RegisterNUICallback('uiLoaded', function(_, cb)
+	client.uiLoaded = true
+	cb(1)
+end)
+
+RegisterNUICallback('getItemData', function(itemName, cb)
+	cb(Items[itemName])
+end)
+
+RegisterNUICallback('removeComponent', function(data, cb)
+	cb(1)
+
+	if not currentWeapon then
+		return TriggerServerEvent('ox_inventory:updateWeapon', 'component', data)
+	end
+
+	if data.slot ~= currentWeapon.slot then
+		return lib.notify({ id = 'weapon_hand_wrong', type = 'error', description = locale('weapon_hand_wrong') })
+	end
+
+	local itemSlot = PlayerData.inventory[currentWeapon.slot]
+
+    if not itemSlot then return end
+
+	for _, component in pairs(Items[data.component].client.component) do
+		if HasPedGotWeaponComponent(playerPed, currentWeapon.hash, component) then
+			for k, v in pairs(itemSlot.metadata.components) do
+				if v == data.component then
+					local success = lib.callback.await('ox_inventory:updateWeapon', false, 'component', k)
+
+					if success then
+						RemoveWeaponComponentFromPed(playerPed, currentWeapon.hash, component)
+						TriggerEvent('ox_inventory:updateWeaponComponent', 'removed', component, data.component)
+					end
+
+					break
+				end
+			end
+		end
+	end
+end)
+
+RegisterNUICallback('removeAmmo', function(slot, cb)
+	cb(1)
+	local slotData = PlayerData.inventory[slot]
+
+	if not slotData or not slotData.metadata.ammo or slotData.metadata.ammo == 0 then return end
+
+	local success = lib.callback.await('ox_inventory:removeAmmoFromWeapon', false, slot)
+
+	if success and slot == currentWeapon?.slot then
+		SetPedAmmo(playerPed, currentWeapon.hash, 0)
+	end
+end)
+
+RegisterNUICallback('useItem', function(slot, cb)
+	useSlot(slot --[[@as number]])
+	cb(1)
+end)
+
+local function giveItemToTarget(serverId, slotId, count)
+    if type(slotId) ~= 'number' then return TypeError('slotId', 'number', type(slotId)) end
+    if count and type(count) ~= 'number' then return TypeError('count', 'number', type(count)) end
+
+    if slotId == currentWeapon?.slot then
+        currentWeapon = Weapon.Disarm(currentWeapon)
+    end
+
+    Utils.PlayAnim(0, 'mp_common', 'givetake1_a', 1.0, 1.0, 2000, 50, 0.0, 0, 0, 0)
+
+    local notification = lib.callback.await('ox_inventory:giveItem', false, slotId, serverId, count or 0)
+
+    if notification then
+        lib.notify({ type = 'error', description = locale(table.unpack(notification)) })
+    end
+end
+
+exports('giveItemToTarget', giveItemToTarget)
+
+local function isGiveTargetValid(ped, coords)
+    if cache.vehicle and GetVehiclePedIsIn(ped, false) == cache.vehicle then
+        return true
+    end
+
+    local entity = Utils.Raycast(1|4|8|16, coords + vec3(0, 0, 0.5), 0.2)
+
+    return entity == ped and IsEntityVisible(ped)
+end
+
+RegisterNUICallback('giveItem', function(data, cb)
+	cb(1)
+
+    if usingItem then return end
+
+	if client.giveplayerlist then
+		local coords = cache.vehicle and GetWorldPositionOfEntityBone(playerPed, 0) or GetEntityCoords(playerPed)
+
+		local nearbyPlayers = lib.getNearbyPlayers(coords, 3.0)
+        local nearbyCount = #nearbyPlayers
+
+		if nearbyCount == 0 then return end
+
+        if nearbyCount == 1 then
+			local option = nearbyPlayers[1]
+
+            if not isGiveTargetValid(option.ped, option.coords) then return end
+
+            return giveItemToTarget(GetPlayerServerId(option.id), data.slot, data.count)
+        end
+
+        local giveList, n = {}, 0
+
+		for i = 1, #nearbyPlayers do
+			local option = nearbyPlayers[i]
+
+            if isGiveTargetValid(option.ped, option.coords) then
+				local playerName = Utils.getPlayerName(option.id)
+				option.id = GetPlayerServerId(option.id)
+                ---@diagnostic disable-next-line: inject-field
+				option.label = playerName
+				n += 1
+				giveList[n] = option
+			end
+		end
+
+        if n == 0 then return end
+
+		lib.registerMenu({
+			id = 'ox_inventory:givePlayerList',
+			title = 'Give item',
+			options = giveList,
+		}, function(selected)
+            giveItemToTarget(giveList[selected].id, data.slot, data.count)
+        end)
+
+		return lib.showMenu('ox_inventory:givePlayerList')
+	end
+
+    if cache.vehicle then
+		local seats = GetVehicleMaxNumberOfPassengers(cache.vehicle) - 1
+
+		if seats >= 0 then
+			local passenger = GetPedInVehicleSeat(cache.vehicle, cache.seat - 2 * (cache.seat % 2) + 1)
+
+			if passenger ~= 0 and IsEntityVisible(passenger) then
+                return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(passenger)), data.slot, data.count)
+			end
+		end
+
+        return
+	end
+
+    local entity = Utils.Raycast(1|2|4|8|16, GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 3.0, 0.5), 0.2)
+
+    if entity and IsPedAPlayer(entity) and IsEntityVisible(entity) and #(GetEntityCoords(playerPed, true) - GetEntityCoords(entity, true)) < 3.0 then
+        return giveItemToTarget(GetPlayerServerId(NetworkGetPlayerIndexFromPed(entity)), data.slot, data.count)
+    end
+end)
+
+RegisterNUICallback('useButton', function(data, cb)
+	useButton(data.id, data.slot)
+	cb(1)
+end)
+
+RegisterNUICallback('exit', function(_, cb)
+	client.closeInventory()
+	cb(1)
+end)
+
+lib.callback.register('ox_inventory:startCrafting', function(id, recipe)
+	recipe = CraftingBenches[id].items[recipe]
+
+	return lib.progressCircle({
+		label = locale('crafting_item', recipe.metadata?.label or Items[recipe.name].label),
+		duration = recipe.duration or 3000,
+		canCancel = true,
+		disable = {
+			move = true,
+			combat = true,
+		},
+		anim = {
+			dict = 'anim@amb@clubhouse@tutorial@bkr_tut_ig3@',
+			clip = 'machinic_loop_mechandplayer',
+		}
+	})
+end)
+
+local swapActive = false
+
+---Synchronise and validate all item movement between the NUI and server.
+RegisterNUICallback('swapItems', function(data, cb)
+    if swapActive or not invOpen or invBusy or usingItem then return cb(false) end
+
+    swapActive = true
+
+	if data.toType == 'newdrop' then
+		if cache.vehicle or IsPedFalling(playerPed) then
+			swapActive = false
+			return cb(false)
+		end
+
+		local coords = GetEntityCoords(playerPed)
+
+		if IsEntityInWater(playerPed) then
+			local destination = vec3(coords.x, coords.y, -200)
+			local handle = StartShapeTestLosProbe(coords.x, coords.y, coords.z, destination.x, destination.y, destination.z, 511, cache.ped, 4)
+
+			while true do
+				Wait(0)
+				local retval, hit, endCoords = GetShapeTestResult(handle)
+
+				if retval ~= 1 then
+					if not hit then return end
+
+					data.coords = vec3(endCoords.x, endCoords.y, endCoords.z + 1.0)
+
+					break
+				end
+			end
+		else
+			data.coords = coords
+		end
+    end
+
+	if currentInstance then
+		data.instance = currentInstance
+	end
+
+	if currentWeapon and data.fromType ~= data.toType then
+		if (data.fromType == 'player' and data.fromSlot == currentWeapon.slot) or (data.toType == 'player' and data.toSlot == currentWeapon.slot) then
+			currentWeapon = Weapon.Disarm(currentWeapon, true)
+		end
+	end
+
+	local success, response, weaponSlot = lib.callback.await('ox_inventory:swapItems', false, data)
+    swapActive = false
+
+	cb(success or false)
+
+	if success then
+        if weaponSlot and currentWeapon then
+            currentWeapon.slot = weaponSlot
+        end
+
+		if response then
+			updateInventory(response.items, response.weight)
+		end
+	elseif response then
+		if type(response) == 'table' then
+			SendNUIMessage({ action = 'refreshSlots', data = { items = response } })
+		else
+			lib.notify({ type = 'error', description = locale(response) })
+		end
+	end
+end)
+
+RegisterNUICallback('buyItem', function(data, cb)
+	---@type boolean, false | { [1]: number, [2]: SlotWithItem, [3]: SlotWithItem | false, [4]: number}, NotifyProps
+	local response, data, message = lib.callback.await('ox_inventory:buyItem', 100, data)
+
+	if data then
+		updateInventory({
+			{
+				item = data[2],
+				inventory = cache.serverId
+			}
+		}, data[4])
+
+		if data[3] then
+			SendNUIMessage({
+				action = 'refreshSlots',
+				data = {
+					items = {
+						{
+							item = data[3],
+							inventory = 'shop'
+						}
+					}
+				}
+			})
+		end
+	end
+
+	if message then
+		lib.notify(message)
+	end
+
+	cb(response)
+end)
+
+RegisterNUICallback('craftItem', function(data, cb)
+	cb(true)
+
+	local id, index = currentInventory.id, currentInventory.index
+
+	for i = 1, data.count do
+		local success, response = lib.callback.await('ox_inventory:craftItem', 200, id, index, data.fromSlot, data.toSlot)
+
+		if not success then
+			if response then lib.notify({ type = 'error', description = locale(response or 'cannot_perform') }) end
+			break
+		end
+	end
+
+	if currentInventory.type ~= 'crafting' then
+		client.openInventory('crafting', { id = id, index = index })
+	end
+end)
+
+lib.callback.register('ox_inventory:getVehicleData', function(netid)
+	local entity = NetworkGetEntityFromNetworkId(netid)
+
+	if entity then
+		return GetEntityModel(entity), GetVehicleClass(entity)
+	end
+end)

--- a/2.47.1/modules/utils/client.lua
+++ b/2.47.1/modules/utils/client.lua
@@ -1,0 +1,312 @@
+if not lib then return end
+
+local Utils = {}
+
+--Holgers Anpassungen
+Utils.Waffensyncaus = false
+--Holgers Anpassungen bis hier
+
+function Utils.PlayAnim(wait, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    lib.requestAnimDict(dict)
+    TaskPlayAnim(cache.ped, dict, name, blendIn, blendOut, duration, flag, rate, lockX, lockY, lockZ)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+function Utils.PlayAnimAdvanced(wait, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+                                time)
+    lib.requestAnimDict(dict)
+    TaskPlayAnimAdvanced(cache.ped, dict, name, posX, posY, posZ, rotX, rotY, rotZ, blendIn, blendOut, duration, flag,
+        time, 0, 0)
+    RemoveAnimDict(dict)
+
+    if wait > 0 then Wait(wait) end
+end
+
+---@param flag number
+---@param destination? vector3
+---@param size? number
+---@return number | false
+---@return number?
+function Utils.Raycast(flag, destination, size)
+    local playerCoords = GetEntityCoords(cache.ped)
+    destination = destination or GetOffsetFromEntityInWorldCoords(cache.ped, 0.0, 2.2, -0.25)
+    local rayHandle = StartShapeTestCapsule(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x,
+        destination.y, destination.z, size or 2.2, flag or 30, cache.ped, 4)
+    while true do
+        Wait(0)
+        local result, _, coords, _, entityHit = GetShapeTestResult(rayHandle)
+        if result ~= 1 then
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, destination.x, destination.y, destination.z, 0, 0, 255, 255)
+            -- DrawLine(playerCoords.x, playerCoords.y, playerCoords.z + 0.5, coords.x, coords.y, coords.z, 255, 0, 0, 255)
+            local entityType
+            if entityHit then entityType = GetEntityType(entityHit) end
+            if entityHit and entityType ~= 0 then
+                return entityHit, entityType
+            end
+            return false
+        end
+    end
+end
+
+function Utils.GetClosestPlayer()
+    local players = GetActivePlayers()
+    local playerCoords = GetEntityCoords(cache.ped)
+    local targetDistance, targetId, targetPed
+
+    for i = 1, #players do
+        local player = players[i]
+
+        if player ~= cache.playerId then
+            local ped = GetPlayerPed(player)
+            local distance = #(playerCoords - GetEntityCoords(ped))
+
+            if distance < (targetDistance or 2) then
+                targetDistance = distance
+                targetId = player
+                targetPed = ped
+            end
+        end
+    end
+
+    return targetId, targetPed
+end
+
+-- Replace ox_inventory notify with ox_lib (backwards compatibility)
+function Utils.Notify(data)
+    data.description = data.text
+    data.text = nil
+    lib.notify(data)
+end
+
+RegisterNetEvent('ox_inventory:notify', Utils.Notify)
+exports('notify', Utils.Notify)
+
+local notifySuppressed = false
+
+---@param value boolean
+local function setNotifySuppressed(value)
+    notifySuppressed = value
+end
+
+RegisterNetEvent('ox_inventory:suppressItemNotifications', setNotifySuppressed)
+exports('suppressItemNotifications', setNotifySuppressed)
+
+function Utils.ItemNotify(data)
+    if notifySuppressed or not client.itemnotify then
+        return
+    end
+
+    SendNUIMessage({ action = 'itemNotify', data = data })
+end
+
+RegisterNetEvent('ox_inventory:itemNotify', Utils.ItemNotify)
+
+---@deprecated
+function Utils.DeleteObject(obj)
+    SetEntityAsMissionEntity(obj, false, true)
+    DeleteObject(obj)
+end
+
+function Utils.DeleteEntity(entity)
+    if DoesEntityExist(entity) then
+        SetEntityAsMissionEntity(entity, false, true)
+        DeleteEntity(entity)
+    end
+end
+
+local rewardTypes = 1 << 0 | 1 << 1 | 1 << 2 | 1 << 3 | 1 << 7 | 1 << 10
+
+local weaponWheelOverride = false
+
+---Enables the weapon wheel, but disables the use of inventory weapons.
+---Mostly used for weaponised vehicles, though could be called for "minigames"
+---@param state? boolean
+---@param override? boolean
+function Utils.WeaponWheel(state, override)
+    if not override and weaponWheelOverride and state == false then
+        return
+    end
+    if client.disableweapons then state = true end
+    if state == nil then state = EnableWeaponWheel end
+
+    if override then
+        weaponWheelOverride = state or false
+    end
+
+    EnableWeaponWheel = state
+    SetWeaponsNoAutoswap(not state)
+    SetWeaponsNoAutoreload(not state)
+
+    if client.suppresspickups then
+        -- CLEAR_PICKUP_REWARD_TYPE_SUPPRESSION | SUPPRESS_PICKUP_REWARD_TYPE
+        return state and N_0x762db2d380b48d04(rewardTypes) or N_0xf92099527db8e2a7(rewardTypes, true)
+    end
+end
+
+exports('weaponWheel', function (state)
+    Utils.WeaponWheel(state, true)
+end)
+
+--Holgers part starts
+
+function Utils.Waffensyncdisable(state)
+	if state == nil then state = Utils.Waffensyncaus end
+	Utils.Waffensyncaus = state
+	Utils.WeaponWheelsyncen()
+end
+
+Utils.WeaponWheelundHotbar = function(state)
+	if state == nil then state = HotbarundWeaponWheel end
+	HotbarundWeaponWheel = state
+	Utils.WeaponWheel(state)
+end
+
+Utils.WeaponWheelsyncen = function ()
+	Utils.ClearWeapons()
+	if not Utils.Waffensyncaus then		
+		Wait(500)
+		local items = exports.ox_inventory:GetPlayerItems()
+		if items ~=nil  then
+			Waffencache = nil
+			Waffencache = {}
+			for k,v in pairs(items) do
+				if string.sub(v.name,1,7) =="WEAPON_"  and v.name ~= "WEAPON_PETROLCAN" then
+					if HasPedGotWeapon(cache.ped,v.name,false) then
+						RemoveWeaponFromPed(cache.ped,v.name)
+					end
+					local hash = GetHashKey(v.name)
+					Waffencache[hash] = {}
+					Waffencache[hash].name = v.name
+					Waffencache[hash].slot = v.slot
+					Waffencache[hash].hash = hash
+
+					GiveWeaponToPed(cache.ped,v.name,1,false,false)
+				end
+			end
+		end
+	end
+end
+
+exports('Weaponsyncdisable', Utils.Waffensyncdisable)
+exports('WeaponWheelandHotbar', Utils.WeaponWheelundHotbar)
+
+--Holgers part ends
+
+function Utils.CreateBlip(settings, coords)
+    local blip = AddBlipForCoord(coords.x, coords.y, coords.z)
+    SetBlipSprite(blip, settings.id)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, settings.scale)
+    SetBlipColour(blip, settings.colour)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName(settings.name)
+    EndTextCommandSetBlipName(blip)
+
+    return blip
+end
+
+---Takes OxTargetBoxZone or legacy zone data (PolyZone) and creates a zone.
+---@param data OxTargetBoxZone | { length: number, minZ: number, maxZ: number, loc: vector3, heading: number, width: number, distance: number }
+---@param options? OxTargetOption[]
+---@return number
+function Utils.CreateBoxZone(data, options)
+    if data.length then
+        local height = math.abs(data.maxZ - data.minZ)
+        local z = data.loc.z + math.abs(data.minZ - data.maxZ) / 2
+        data.coords = vec3(data.loc.x, data.loc.y, z)
+        data.size = vec3(data.width, data.length, height)
+        data.rotation = data.heading
+        data.loc = nil
+        data.heading = nil
+        data.length = nil
+        data.width = nil
+        data.maxZ = nil
+        data.minZ = nil
+    end
+
+    if not data.options and options then
+        local distance = data.distance or 2.0
+
+        for k, v in pairs(options) do
+            if not v.distance then
+                v.distance = distance
+            end
+        end
+
+        data.options = options
+    end
+
+    return exports.ox_target:addBoxZone(data)
+end
+
+local hasTextUi
+
+---@param point CPoint
+function Utils.nearbyMarker(point)
+    DrawMarker(point.marker.type, point.coords.x, point.coords.y, point.coords.z, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, point.marker.scale[1], point.marker.scale[2], point.marker.scale[3],
+        ---@diagnostic disable-next-line: param-type-mismatch
+        point.marker.colour[1], point.marker.colour[2], point.marker.colour[3], 222, false, false, 0, true, false, false, false)
+
+    if point.isClosest and point.currentDistance < 1.2 then
+        if not hasTextUi then
+            hasTextUi = point
+            lib.showTextUI(point.prompt.message, point.prompt.options)
+        end
+
+        if IsControlJustReleased(0, 38) then
+            CreateThread(function()
+                if point.inv == 'policeevidence' then
+                    client.openInventory('policeevidence')
+                elseif point.inv == 'crafting' then
+                    client.openInventory('crafting', { id = point.benchid, index = point.index })
+                else
+                    client.openInventory(point.inv or 'drop', { id = point.invId, type = point.type })
+                end
+            end)
+        end
+    elseif hasTextUi == point then
+        hasTextUi = nil
+        lib.hideTextUI()
+    end
+end
+
+function Utils.blurIn()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeIn(100)
+end
+
+function Utils.blurOut()
+    if IsScreenblurFadeRunning() then
+        DisableScreenblurFade()
+    end
+
+    TriggerScreenblurFadeOut(250)
+end
+
+---@param serverID number
+---@return string
+local function defaultGetPlayerName(serverID)
+    local playerName = GetPlayerName(serverID)
+    return ('[%d] %s'):format(serverID, playerName)
+end
+
+local getPlayerName = defaultGetPlayerName
+
+exports('setGetPlayerNameMethod', function (fn)
+    if type(fn) == "function" then
+        getPlayerName = fn
+    else
+        getPlayerName = defaultGetPlayerName
+    end
+end)
+
+function Utils.getPlayerName(serverId)
+    return getPlayerName(serverId)
+end
+
+return Utils

--- a/2.47.1/modules/weapon/client.lua
+++ b/2.47.1/modules/weapon/client.lua
@@ -1,0 +1,666 @@
+if not lib then return end
+
+local Weapon = {}
+local Items = require 'modules.items.client'
+local Utils = require 'modules.utils.client'
+
+-- generic group animation data
+local anims = {}
+anims[`GROUP_MELEE`] = { 'melee@holster', 'unholster', 200, 'melee@holster', 'holster', 600 }
+anims[`GROUP_PISTOL`] = { 'reaction@intimidation@cop@unarmed', 'intro', 400, 'reaction@intimidation@cop@unarmed', 'outro', 450 }
+anims[`GROUP_STUNGUN`] = anims[`GROUP_PISTOL`]
+
+local function vehicleIsCycle(vehicle)
+	local class = GetVehicleClass(vehicle)
+	return class == 8 or class == 13
+end
+
+function Weapon.Equip(item, data, noWeaponAnim)
+	local playerPed = cache.ped
+	local coords = GetEntityCoords(playerPed, true)
+    local sleep
+
+	if client.weaponanims then
+		if noWeaponAnim or (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			goto skipAnim
+		end
+
+		local anim = data.anim or anims[GetWeapontypeGroup(data.hash)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+		sleep = anim and anim[3] or 1200
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+	end
+
+	::skipAnim::
+
+	GiveWeaponToPed(playerPed, -1569615261, 0, false, true) --added by Holger
+
+	item.hash = data.hash
+	item.ammo = data.ammoname
+	item.melee = GetWeaponDamageType(data.hash) == 2 and 0
+	item.timer = 0
+	item.throwable = data.throwable
+	item.group = GetWeapontypeGroup(item.hash)
+
+	GiveWeaponToPed(playerPed, data.hash, 0, false, true)
+
+	if item.metadata.tint then SetPedWeaponTintIndex(playerPed, data.hash, item.metadata.tint) end
+
+	if item.metadata.components then
+		for i = 1, #item.metadata.components do
+			local components = Items[item.metadata.components[i]].client.component
+			for v=1, #components do
+				local component = components[v]
+				if DoesWeaponTakeWeaponComponent(data.hash, component) then
+					if not HasPedGotWeaponComponent(playerPed, data.hash, component) then
+						GiveWeaponComponentToPed(playerPed, data.hash, component)
+					end
+				end
+			end
+		end
+	end
+
+	if item.metadata.specialAmmo then
+		local clipComponentKey = ('%s_CLIP'):format(data.model:gsub('WEAPON_', 'COMPONENT_'))
+		local specialClip = ('%s_%s'):format(clipComponentKey, item.metadata.specialAmmo:upper())
+
+		if DoesWeaponTakeWeaponComponent(data.hash, specialClip) then
+			GiveWeaponComponentToPed(playerPed, data.hash, specialClip)
+		end
+	end
+
+	local ammo = item.metadata.ammo or item.throwable and 1 or 0
+
+	SetCurrentPedWeapon(playerPed, data.hash, true)
+	SetPedCurrentWeaponVisible(playerPed, true, false, false, false)
+	SetWeaponsNoAutoswap(true)
+	SetPedAmmo(playerPed, data.hash, ammo)
+	SetTimeout(0, function() RefillAmmoInstantly(playerPed) end)
+
+	if item.group == `GROUP_PETROLCAN` or item.group == `GROUP_FIREEXTINGUISHER` then
+		item.metadata.ammo = item.metadata.durability
+		SetPedInfiniteAmmo(playerPed, true, data.hash)
+	end
+
+	TriggerEvent('ox_inventory:currentWeapon', item)
+
+	if client.weaponnotify then
+		Utils.ItemNotify({ item, 'ui_equipped' })
+	end
+
+	return item, sleep
+end
+
+function Weapon.Disarm(currentWeapon, noAnim, waffenlos) --waffenlos added by Holger
+	if currentWeapon?.timer then
+		currentWeapon.timer = nil
+
+        TriggerServerEvent('ox_inventory:updateWeapon')
+		--SetPedAmmo(cache.ped, currentWeapon.hash, 0)	--disabled by Holger
+
+		if client.weaponanims and not noAnim then
+			if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+				goto skipAnim
+			end
+
+			ClearPedSecondaryTask(cache.ped)
+
+			local item = Items[currentWeapon.name]
+			local coords = GetEntityCoords(cache.ped, true)
+			local anim = item.anim or anims[GetWeapontypeGroup(currentWeapon.hash)]
+
+			if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+				anim = nil
+			end
+
+			local sleep = anim and anim[6] or 1400
+
+			Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+		end
+
+		::skipAnim::
+
+		if waffenlos then	--if added by Holger
+			GiveWeaponToPed(cache.ped, currentWeapon.hash, 0, false, true)
+		end
+
+		if client.weaponnotify then
+			Utils.ItemNotify({ currentWeapon, 'ui_holstered' })
+		end
+
+		TriggerEvent('ox_inventory:currentWeapon')
+	end
+
+end --closing end for Weapon.Disarm
+
+--[[ 	Utils.WeaponWheel() --disabled by Holger
+	RemoveAllPedWeapons(cache.ped, true)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+		SetPlayerParachuteTintIndex(PlayerData.id, client.parachute?[2] or -1)
+	end
+end ]]
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+
+--Holgers part starts
+
+
+Weapon.triggerAnimation = function(waffenhashalt,waffenhashneu,wert)
+	if wert then
+		local playerPed = cache.ped
+		local coords = GetEntityCoords(playerPed, true)
+		local sleep
+
+		if  (cache.vehicle and vehicleIsCycle(cache.vehicle)) then
+			return
+		end
+
+		local anim = anims[GetWeapontypeGroup(waffenhashneu)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		GiveWeaponToPed(playerPed, -1569615261, 0, false, true)
+
+		sleep = anim and anim[3] or 1100
+
+		Utils.PlayAnimAdvanced(sleep, anim and anim[1] or 'reaction@intimidation@1h', anim and anim[2] or 'intro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(playerPed), 8.0, 3.0, sleep*2, 50, 0.1)
+
+		GiveWeaponToPed(playerPed, waffenhashneu, 250, false, true)
+		sleep = 0
+
+	else
+		if cache.vehicle and vehicleIsCycle(cache.vehicle) then
+			return
+		end
+		local sleep
+
+
+		ClearPedSecondaryTask(cache.ped)
+
+		local coords = GetEntityCoords(cache.ped, true)
+		local anim = anims[GetWeapontypeGroup(waffenhashalt)]
+
+		if anim == anims[`GROUP_PISTOL`] and not client.hasGroup(shared.police) then
+			anim = nil
+		end
+
+
+		local sleep = anim and anim[6] or 1000
+
+		GiveWeaponToPed(cache.ped, waffenhashalt, 0, false, true)
+		
+		Utils.PlayAnimAdvanced(sleep, anim and anim[4] or 'reaction@intimidation@1h', anim and anim[5] or 'outro', coords.x, coords.y, coords.z, 0, 0, GetEntityHeading(cache.ped), 8.0, 3.0, sleep, 50, 0)
+	end
+
+end
+
+--Holgers part ends
+
+function Weapon.ClearAll(currentWeapon)
+	Weapon.Disarm(currentWeapon)
+
+	if client.parachute then
+		local chute = `GADGET_PARACHUTE`
+		GiveWeaponToPed(cache.ped, chute, 0, true, false)
+		SetPedGadget(cache.ped, chute, true)
+	end
+end
+
+Utils.Disarm = Weapon.Disarm
+Utils.ClearWeapons = Weapon.ClearAll
+
+--added by Holger thanks to 5Labs for providing the list
+
+Weapon.WeaponByHash = {
+	[-1768145561] = {
+	["name"] = 'WEAPON_SPECIALCARBINE_MK2',
+	["label"] = 'Special Carbine MK2',
+	},
+	[487013001] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN',
+	["label"] = 'Pump Shotgun',
+	},
+	[-1075685676] = {
+	["name"] = 'WEAPON_PISTOL_MK2',
+	["label"] = 'Pistol MK2',
+	},
+	[-1238556825] = {
+	["name"] = 'WEAPON_RAYMINIGUN',
+	["label"] = 'Widowmaker',
+	},
+	[-1834847097] = {
+	["name"] = 'WEAPON_DAGGER',
+	["label"] = 'Dagger',
+	},
+	[-2067956739] = {
+	["name"] = 'WEAPON_CROWBAR',
+	["label"] = 'Crowbar',
+	},
+	[650961374] = {
+	["name"] = 'WEAPON_TEARGAS',
+	["label"] = 'Tear Gas',
+	},
+	[-618237638] = {
+	["name"] = 'WEAPON_EMPLAUNCHER',
+	["label"] = 'Compact EMP Launcher',
+	},
+	[-2084633992] = {
+	["name"] = 'WEAPON_CARBINERIFLE',
+	["label"] = 'Carbine Rifle',
+	},
+	[940833800] = {
+	["name"] = 'WEAPON_STONE_HATCHET',
+	["label"] = 'Stone Hatchet',
+	},
+	[-1716589765] = {
+	["name"] = 'WEAPON_PISTOL50',
+	["label"] = 'Pistol .50',
+	},
+	[-1716189206] = {
+	["name"] = 'WEAPON_KNIFE',
+	["label"] = 'Knife',
+	},
+	[1853742572] = {
+	["name"] = 'WEAPON_PRECISIONRIFLE',
+	["label"] = 'Precision Rifle',
+	},
+	[-1076751822] = {
+	["name"] = 'WEAPON_SNSPISTOL',
+	["label"] = 'SNS Pistol',
+	},
+	[1198879012] = {
+	["name"] = 'WEAPON_FLAREGUN',
+	["label"] = 'Flare Gun',
+	},
+	[-1355376991] = {
+	["name"] = 'WEAPON_RAYPISTOL',
+	["label"] = 'Up-n-Atomizer',
+	},
+	[-1813897027] = {
+	["name"] = 'WEAPON_GRENADE',
+	["label"] = 'Grenade',
+	},
+	[1737195953] = {
+	["name"] = 'WEAPON_NIGHTSTICK',
+	["label"] = 'Nightstick',
+	},
+	[1198256469] = {
+	["name"] = 'WEAPON_RAYCARBINE',
+	["label"] = 'Unholy Hellbringer',
+	},
+	[465894841] = {
+	["name"] = 'WEAPON_PISTOLXM3',
+	["label"] = 'WM 29 Pistol',
+	},
+	[1432025498] = {
+	["name"] = 'WEAPON_PUMPSHOTGUN_MK2',
+	["label"] = 'Pump Shotgun MK2',
+	},
+	[100416529] = {
+	["name"] = 'WEAPON_SNIPERRIFLE',
+	["label"] = 'Sniper Rifle',
+	},
+	[1593441988] = {
+	["name"] = 'WEAPON_COMBATPISTOL',
+	["label"] = 'Glock',
+	},
+	[-581044007] = {
+	["name"] = 'WEAPON_MACHETE',
+	["label"] = 'Machete',
+	},
+	[-275439685] = {
+	["name"] = 'WEAPON_DBSHOTGUN',
+	["label"] = 'Double Barrel Shotgun',
+	},
+	[-1063057011] = {
+	["name"] = 'WEAPON_SPECIALCARBINE',
+	["label"] = 'Special Carbine',
+	},
+	[-1951375401] = {
+	["name"] = 'WEAPON_FLASHLIGHT',
+	["label"] = 'Flashlight',
+	},
+	[727643628] = {
+	["name"] = 'WEAPON_CERAMICPISTOL',
+	["label"] = 'Ceramic Pistol',
+	},
+	[584646201] = {
+	["name"] = 'WEAPON_APPISTOL',
+	["label"] = 'AP Pistol',
+	},
+	[-1045183535] = {
+	["name"] = 'WEAPON_REVOLVER',
+	["label"] = 'Revolver',
+	},
+	[-22923932] = {
+	["name"] = 'WEAPON_RAILGUNXM3',
+	["label"] = 'Railgun XM3',
+	},
+	[324215364] = {
+	["name"] = 'WEAPON_MICROSMG',
+	["label"] = 'Micro SMG',
+	},
+	[-1600701090] = {
+	["name"] = 'WEAPON_BZGAS',
+	["label"] = 'BZ Gas',
+	},
+	[-1168940174] = {
+	["name"] = 'WEAPON_HAZARDCAN',
+	["label"] = 'Hazard Can',
+	},
+	[-608341376] = {
+	["name"] = 'WEAPON_COMBATMG_MK2',
+	["label"] = 'Combat MG MK2',
+	},
+	[-538741184] = {
+	["name"] = 'WEAPON_SWITCHBLADE',
+	["label"] = 'Switchblade',
+	},
+	[984333226] = {
+	["name"] = 'WEAPON_HEAVYSHOTGUN',
+	["label"] = 'Heavy Shotgun',
+	},
+	[1785463520] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE_MK2',
+	["label"] = 'Marksman Rifle MK2',
+	},
+	[2024373456] = {
+	["name"] = 'WEAPON_SMG_MK2',
+	["label"] = 'SMG Mk2',
+	},
+	[1649403952] = {
+	["name"] = 'WEAPON_COMPACTRIFLE',
+	["label"] = 'Compact Rifle',
+	},
+	[615608432] = {
+	["name"] = 'WEAPON_MOLOTOV',
+	["label"] = 'Molotov',
+	},
+	[600439132] = {
+	["name"] = 'WEAPON_BALL',
+	["label"] = 'Ball',
+	},
+	[-952879014] = {
+	["name"] = 'WEAPON_MARKSMANRIFLE',
+	["label"] = 'Marksman Rifle',
+	},
+	[-610080759] = {
+	["name"] = 'WEAPON_METALDETECTOR',
+	["label"] = 'Metal Detector',
+	},
+	[2017895192] = {
+	["name"] = 'WEAPON_SAWNOFFSHOTGUN',
+	["label"] = 'Sawn Off Shotgun',
+	},
+	[-1568386805] = {
+	["name"] = 'WEAPON_GRENADELAUNCHER',
+	["label"] = 'Grenade Launcher',
+	},
+	[-270015777] = {
+	["name"] = 'WEAPON_ASSAULTSMG',
+	["label"] = 'Assault SMG',
+	},
+	[-1466123874] = {
+	["name"] = 'WEAPON_MUSKET',
+	["label"] = 'Musket',
+	},
+	[-37975472] = {
+	["name"] = 'WEAPON_SMOKEGRENADE',
+	["label"] = 'Smoke Grenade',
+	},
+	[-1654528753] = {
+	["name"] = 'WEAPON_BULLPUPSHOTGUN',
+	["label"] = 'Bullpup Shotgun',
+	},
+	[1317494643] = {
+	["name"] = 'WEAPON_HAMMER',
+	["label"] = 'Hammer',
+	},
+	[137902532] = {
+	["name"] = 'WEAPON_VINTAGEPISTOL',
+	["label"] = 'Vintage Pistol',
+	},
+	[-853065399] = {
+	["name"] = 'WEAPON_BATTLEAXE',
+	["label"] = 'Battle Axe',
+	},
+	[-1660422300] = {
+	["name"] = 'WEAPON_MG',
+	["label"] = 'Machine Gun',
+	},
+	[1470379660] = {
+	["name"] = 'WEAPON_GADGETPISTOL',
+	["label"] = 'Perico Pistol',
+	},
+	[-1853920116] = {
+	["name"] = 'WEAPON_NAVYREVOLVER',
+	["label"] = 'Navy Revolver',
+	},
+	[94989220] = {
+	["name"] = 'WEAPON_COMBATSHOTGUN',
+	["label"] = 'Combat Shotgun',
+	},
+	[2144741730] = {
+	["name"] = 'WEAPON_COMBATMG',
+	["label"] = 'Combat MG',
+	},
+	[317205821] = {
+	["name"] = 'WEAPON_AUTOSHOTGUN',
+	["label"] = 'Sweeper Shotgun',
+	},
+	[883325847] = {
+	["name"] = 'WEAPON_PETROLCAN',
+	["label"] = 'Gas Can',
+	},
+	[-1357824103] = {
+	["name"] = 'WEAPON_ADVANCEDRIFLE',
+	["label"] = 'Advanced Rifle',
+	},
+	[736523883] = {
+	["name"] = 'WEAPON_SMG',
+	["label"] = 'SMG',
+	},
+	[205991906] = {
+	["name"] = 'WEAPON_HEAVYSNIPER',
+	["label"] = 'Heavy Sniper',
+	},
+	[-1312131151] = {
+	["name"] = 'WEAPON_RPG',
+	["label"] = 'RPG',
+	},
+	[-771403250] = {
+	["name"] = 'WEAPON_HEAVYPISTOL',
+	["label"] = 'Heavy Pistol',
+	},
+	[-879347409] = {
+	["name"] = 'WEAPON_REVOLVER_MK2',
+	["label"] = 'Revolver MK2',
+	},
+	[-494615257] = {
+	["name"] = 'WEAPON_ASSAULTSHOTGUN',
+	["label"] = 'Assault Shotgun',
+	},
+	[-947031628] = {
+	["name"] = 'WEAPON_HEAVYRIFLE',
+	["label"] = 'Heavy Rifle',
+	},
+	[-1420407917] = {
+	["name"] = 'WEAPON_PROXMINE',
+	["label"] = 'Proximity Mine',
+	},
+	[-619010992] = {
+	["name"] = 'WEAPON_MACHINEPISTOL',
+	["label"] = 'Machine Pistol',
+	},
+	[-1746263880] = {
+	["name"] = 'WEAPON_DOUBLEACTION',
+	["label"] = 'Double Action Revolver',
+	},
+	[125959754] = {
+	["name"] = 'WEAPON_COMPACTLAUNCHER',
+	["label"] = 'Compact Grenade Launcher',
+	},
+	[2132975508] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE',
+	["label"] = 'Bullpup Rifle',
+	},
+	[-86904375] = {
+	["name"] = 'WEAPON_CARBINERIFLE_MK2',
+	["label"] = 'Carbine Rifle MK2',
+	},
+	[453432689] = {
+	["name"] = 'WEAPON_PISTOL',
+	["label"] = 'Pistol',
+	},
+	[-1074790547] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE',
+	["label"] = 'Assault Rifle',
+	},
+	[1627465347] = {
+	["name"] = 'WEAPON_GUSENBERG',
+	["label"] = 'Gusenberg',
+	},
+	[911657153] = {
+	["name"] = 'WEAPON_STUNGUN',
+	["label"] = 'Tazer',
+	},
+	[-1121678507] = {
+	["name"] = 'WEAPON_MINISMG',
+	["label"] = 'Mini SMG',
+	},
+	[171789620] = {
+	["name"] = 'WEAPON_COMBATPDW',
+	["label"] = 'Combat PDW',
+	},
+	[1141786504] = {
+	["name"] = 'WEAPON_GOLFCLUB',
+	["label"] = 'Golf Club',
+	},
+	[1834241177] = {
+	["name"] = 'WEAPON_RAILGUN',
+	["label"] = 'Railgun',
+	},
+	[1119849093] = {
+	["name"] = 'WEAPON_MINIGUN',
+	["label"] = 'Minigun',
+	},
+	[961495388] = {
+	["name"] = 'WEAPON_ASSAULTRIFLE_MK2',
+	["label"] = 'Assault Rifle MK2',
+	},
+	[406929569] = {
+	["name"] = 'WEAPON_FERTILIZERCAN',
+	["label"] = 'Fertilizer Can',
+	},
+	[1233104067] = {
+	["name"] = 'WEAPON_FLARE',
+	["label"] = 'Flare',
+	},
+	[419712736] = {
+	["name"] = 'WEAPON_WRENCH',
+	["label"] = 'Wrench',
+	},
+	[-2009644972] = {
+	["name"] = 'WEAPON_SNSPISTOL_MK2',
+	["label"] = 'SNS Pistol MK2',
+	},
+	[-102973651] = {
+	["name"] = 'WEAPON_HATCHET',
+	["label"] = 'Hatchet',
+	},
+	[-2066285827] = {
+	["name"] = 'WEAPON_BULLPUPRIFLE_MK2',
+	["label"] = 'Bullpup Rifle MK2',
+	},
+	[-1169823560] = {
+	["name"] = 'WEAPON_PIPEBOMB',
+	["label"] = 'Pipe Bomb',
+	},
+	[1703483498] = {
+	["name"] = 'WEAPON_CANDYCANE',
+	["label"] = 'Candy Cane',
+	},
+	[-598887786] = {
+	["name"] = 'WEAPON_MARKSMANPISTOL',
+	["label"] = 'Marksman Pistol',
+	},
+	[350597077] = {
+	["name"] = 'WEAPON_TECPISTOL',
+	["label"] = 'Tactical SMG',
+	},
+	[-1786099057] = {
+	["name"] = 'WEAPON_BAT',
+	["label"] = 'Bat',
+	},
+	[2138347493] = {
+	["name"] = 'WEAPON_FIREWORK',
+	["label"] = 'Firework Launcher',
+	},
+	[-1658906650] = {
+	["name"] = 'WEAPON_MILITARYRIFLE',
+	["label"] = 'Military Rifle',
+	},
+	[-656458692] = {
+	["name"] = 'WEAPON_KNUCKLE',
+	["label"] = 'Knuckle Dusters',
+	},
+	[126349499] = {
+	["name"] = 'WEAPON_SNOWBALL',
+	["label"] = 'Snow Ball',
+	},
+	[177293209] = {
+	["name"] = 'WEAPON_HEAVYSNIPER_MK2',
+	["label"] = 'Heavy Sniper MK2',
+	},
+	[-774507221] = {
+	["name"] = 'WEAPON_TACTICALRIFLE',
+	["label"] = 'Tactical Rifle',
+	},
+	[101631238] = {
+	["name"] = 'WEAPON_FIREEXTINGUISHER',
+	["label"] = 'Fire Extinguisher',
+	},
+	[-102323637] = {
+	["name"] = 'WEAPON_BOTTLE',
+	["label"] = 'Bottle',
+	},
+	[741814745] = {
+	["name"] = 'WEAPON_STICKYBOMB',
+	["label"] = 'Sticky Bomb',
+	},
+	[1672152130] = {
+	["name"] = 'WEAPON_HOMINGLAUNCHER',
+	["label"] = 'Homing Launcher',
+	},
+	[-1810795771] = {
+	["name"] = 'WEAPON_POOLCUE',
+	["label"] = 'Pool Cue',
+	},
+}
+
+
+return Weapon

--- a/example_script/fxmanifest.lua
+++ b/example_script/fxmanifest.lua
@@ -1,0 +1,4 @@
+fx_version "adamant"
+game "gta5"
+
+client_script 'script.lua'

--- a/example_script/script.lua
+++ b/example_script/script.lua
@@ -1,0 +1,3 @@
+exports["ox_inventory"]:WeaponWheelandHotbar(true)
+exports["ox_inventory"]:weaponWheel(true)
+exports["ox_inventory"]:Weaponsyncdisable(true)


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Update patch files to latest ox_inventory (c4dfba5)</h1>
<h2>Summary</h2>
<p>Ports all of Holger's weapon wheel / hotbar / weaponsync modifications forward from <code>2.43.3</code> to the current HEAD of <a href="https://github.com/overextended/ox_inventory">overextended/ox_inventory</a> (commit <code>c4dfba5</code>, 2025-05-15).</p>
<hr>
<h2>Files changed</h2>

File | Status
-- | --
latest/client.lua | Added
latest/modules/utils/client.lua | Added
latest/modules/weapon/client.lua | Added


<hr>
<h2>What changed in upstream since 2.43.3</h2>
<p>The following upstream changes required careful merging to preserve Holger's modifications:</p>
<h3><code>client.lua</code></h3>
<ul>
<li><strong><code>useSlot</code></strong> — upstream refactored the weapon equip block; the <code>EnableWeaponWheel</code> early-return was restructured. Holger's dual-branch logic (weapon wheel mode vs hotbar mode, with the <code>dings</code> parameter for disarm behaviour) has been re-applied around the new structure.</li>
<li><strong><code>canSteal</code> check</strong> — upstream replaced the <code>shared.police</code> group guard with <code>Player(serverId).state.canSteal</code>; merged correctly alongside Holger's unchanged code in that region.</li>
<li><strong><code>client.closeInventory()</code></strong> — upstream dropped the <code>server</code> parameter; <code>currentInventory</code> now resets to <code>defaultInventory</code> instead of <code>nil</code>. Holger's code in this area had no conflict.</li>
<li><strong><code>Inventory.Dumpsters</code></strong> — upstream changed from <code>Inventory.Dumpsters[model]</code> (table lookup) to <code>Inventory.Dumpsters:includes(model)</code> (method call); carried through correctly.</li>
<li><strong><code>TriggerScreenblurFadeIn/Out</code></strong> calls replaced with <code>Utils.blurIn()</code> / <code>Utils.blurOut()</code> helpers; no conflict with Holger's code.</li>
<li><strong><code>RegisterCommand('steal', ...)</code></strong> now wrapped in an <code>if client.enablestealcommand then</code> guard; no conflict.</li>
<li><strong><code>OpenInventory</code> class annotation</strong> added by upstream; no conflict.</li>
</ul>
<h3><code>modules/utils/client.lua</code></h3>
<ul>
<li><strong><code>Utils.WeaponWheel()</code></strong> — upstream added an <code>override</code> parameter and a <code>weaponWheelOverride</code> local guard so vehicle/minigame overrides can't be cleared by normal callers. The existing <code>weaponWheel</code> export now wraps the function with <code>override = true</code>. Holger's <code>WeaponWheelsyncen()</code> calls <code>Utils.WeaponWheel()</code> without override, which is the correct behaviour — it will properly defer to any active override.</li>
<li><strong><code>suppressItemNotifications</code></strong> — new upstream feature (net event + export) for suppressing item pickup notifications; no conflict with Holger's additions.</li>
<li><strong><code>Utils.blurIn()</code> / <code>Utils.blurOut()</code></strong> — new upstream helpers wrapping screenblur with fade cancellation; added by upstream, no conflict.</li>
<li><strong><code>Utils.getPlayerName()</code> / <code>setGetPlayerNameMethod</code></strong> — new upstream export for customising player name display; no conflict.</li>
<li><strong><code>DrawMarker</code></strong> call in point rendering — upstream changed hardcoded values to <code>point.marker.type</code>, <code>point.marker.scale</code>, <code>point.marker.colour</code>; carried through correctly.</li>
<li>Holger's three exports (<code>Weaponsyncdisable</code>, <code>WeaponWheelandHotbar</code>, <code>weaponWheel</code>) all preserved.</li>
</ul>
<h3><code>modules/weapon/client.lua</code></h3>
<ul>
<li><strong><code>Weapon.Disarm()</code></strong> — upstream added no significant logic changes to the core of this function; Holger's <code>waffenlos</code> parameter, disabled <code>SetPedAmmo</code>, disabled <code>Utils.WeaponWheel()</code> + <code>RemoveAllPedWeapons</code> block, and conditional <code>GiveWeaponToPed</code> are all preserved. The commented-out block <code>--[[ ... end ]]</code> correctly wraps the three upstream lines that Holger disables.</li>
<li><strong><code>Weapon.Equip()</code></strong> — upstream made no structural changes; Holger's fist weapon give (<code>-1569615261</code>) before the equip animation is preserved.</li>
<li>Holger's <code>Weapon.triggerAnimation()</code> and <code>Weapon.WeaponByHash</code> table are carried forward unchanged.</li>
</ul>
<hr>
<h2>How to use</h2>
<ol>
<li>Clone or pull the latest <a href="https://github.com/overextended/ox_inventory">overextended/ox_inventory</a>.</li>
<li>Copy the three files from <code>2.47.0/</code> into your ox_inventory folder, preserving the directory structure:
<pre><code>ox_inventory/├── client.lua                        ← replace├── modules/│   ├── utils/│   │   └── client.lua                ← replace│   └── weapon/│       └── client.lua                ← replace
</code></pre></li>
<li>The exports are unchanged from previous versions:
<pre><code class="language-lua">exports["ox_inventory"]:weaponWheel(true)          -- enable weapon wheelexports["ox_inventory"]:weaponWheel(false)          -- enable hotbarexports["ox_inventory"]:Weaponsyncdisable(true)     -- disable weapon sync (FFA etc.)exports["ox_inventory"]:WeaponWheelandHotbar(true)  -- enable combo modeexports["ox_inventory"]:WeaponWheelandHotbar(false) -- back to hotbar only
</code></pre></li>
</ol>
<hr>
<h2>Notes</h2>
<ul>
<li>All Holger modifications are marked with <code>--Holger</code> / <code>--Holgers Anpassungen</code> comments throughout, as in previous versions — searching for <code>Holger</code> will locate every change.</li>
<li>Tested against ox_inventory commit <code>c4dfba531e9d230c3b94d71ae4086c3f9789ef2a</code> (2025-05-15). If upstream moves significantly again, the three diff regions to watch are <code>useSlot</code> in <code>client.lua</code>, <code>Utils.WeaponWheel</code> in <code>modules/utils/client.lua</code>, and <code>Weapon.Disarm</code> in <code>modules/weapon/client.lua</code>.</li>
<li>The <code>oxconfig.cfg</code> is unchanged from the previous release.</li>
</ul></body></html><!--EndFragment-->
</body>
</html>